### PR TITLE
HEC-981 adding extra dteTime checked field in tax match Response

### DIFF
--- a/app/uk/gov/hmrc/hec/controllers/TaxCheckController.scala
+++ b/app/uk/gov/hmrc/hec/controllers/TaxCheckController.scala
@@ -70,7 +70,8 @@ class TaxCheckController @Inject() (
             result => Ok(Json.toJson(result))
           )
 
-      case JsError(_) =>
+      case JsError(e) =>
+        logger.warn(s"error is $e")
         logger.warn("Could not parse JSON")
         Future.successful(BadRequest)
     }

--- a/app/uk/gov/hmrc/hec/controllers/TaxCheckController.scala
+++ b/app/uk/gov/hmrc/hec/controllers/TaxCheckController.scala
@@ -70,8 +70,7 @@ class TaxCheckController @Inject() (
             result => Ok(Json.toJson(result))
           )
 
-      case JsError(e) =>
-        logger.warn(s"error is $e")
+      case JsError(_) =>
         logger.warn("Could not parse JSON")
         Future.successful(BadRequest)
     }

--- a/app/uk/gov/hmrc/hec/models/HECTaxCheckMatchResult.scala
+++ b/app/uk/gov/hmrc/hec/models/HECTaxCheckMatchResult.scala
@@ -19,15 +19,20 @@ package uk.gov.hmrc.hec.models
 import julienrf.json.derived
 import play.api.libs.json.OFormat
 
+import java.time.ZonedDateTime
+
 sealed trait HECTaxCheckMatchResult
 
 object HECTaxCheckMatchResult {
 
-  final case class NoMatch(matchRequest: HECTaxCheckMatchRequest) extends HECTaxCheckMatchResult
+  final case class NoMatch(matchRequest: HECTaxCheckMatchRequest, dateTimeChecked: ZonedDateTime)
+      extends HECTaxCheckMatchResult
 
-  final case class Match(matchRequest: HECTaxCheckMatchRequest) extends HECTaxCheckMatchResult
+  final case class Match(matchRequest: HECTaxCheckMatchRequest, dateTimeChecked: ZonedDateTime)
+      extends HECTaxCheckMatchResult
 
-  final case class Expired(matchRequest: HECTaxCheckMatchRequest) extends HECTaxCheckMatchResult
+  final case class Expired(matchRequest: HECTaxCheckMatchRequest, dateTimeChecked: ZonedDateTime)
+      extends HECTaxCheckMatchResult
 
   implicit val format: OFormat[HECTaxCheckMatchResult] = derived.oformat()
 

--- a/app/uk/gov/hmrc/hec/util/TimeProvider.scala
+++ b/app/uk/gov/hmrc/hec/util/TimeProvider.scala
@@ -16,13 +16,18 @@
 
 package uk.gov.hmrc.hec.util
 
-import java.time.{Clock, LocalDate, ZoneId, ZonedDateTime}
+import com.google.inject.{ImplementedBy, Inject}
 
-object TimeUtils {
+import java.time.ZonedDateTime
+import javax.inject.Singleton
 
-  val clock: Clock = Clock.systemUTC()
+@ImplementedBy(classOf[TimeProviderImpl])
+trait TimeProvider {
+  def currentDateTime: ZonedDateTime
+}
 
-  def today(): LocalDate           = LocalDate.now(clock)
-  def todayByZone(): ZonedDateTime = ZonedDateTime.now(ZoneId.of("Europe/London"))
-
+@Singleton
+class TimeProviderImpl extends TimeProvider {
+  @Inject()
+  override def currentDateTime: ZonedDateTime = TimeUtils.todayByZone()
 }

--- a/app/uk/gov/hmrc/hec/util/TimeProvider.scala
+++ b/app/uk/gov/hmrc/hec/util/TimeProvider.scala
@@ -29,5 +29,5 @@ trait TimeProvider {
 @Singleton
 class TimeProviderImpl extends TimeProvider {
   @Inject()
-  override def currentDateTime: ZonedDateTime = TimeUtils.todayByZone()
+  override def currentDateTime: ZonedDateTime = TimeUtils.now()
 }

--- a/app/uk/gov/hmrc/hec/util/TimeUtils.scala
+++ b/app/uk/gov/hmrc/hec/util/TimeUtils.scala
@@ -22,7 +22,7 @@ object TimeUtils {
 
   val clock: Clock = Clock.systemUTC()
 
-  def today(): LocalDate           = LocalDate.now(clock)
-  def todayByZone(): ZonedDateTime = ZonedDateTime.now(ZoneId.of("Europe/London"))
+  def today(): LocalDate   = LocalDate.now(clock)
+  def now(): ZonedDateTime = ZonedDateTime.now(ZoneId.of("Europe/London"))
 
 }

--- a/test/uk/gov/hmrc/hec/controllers/TaxCheckControllerSpec.scala
+++ b/test/uk/gov/hmrc/hec/controllers/TaxCheckControllerSpec.scala
@@ -32,6 +32,7 @@ import uk.gov.hmrc.hec.models.ids.{CRN, GGCredId, NINO, SAUTR}
 import uk.gov.hmrc.hec.models.licence.{LicenceDetails, LicenceExpiryDate, LicenceTimeTrading, LicenceType, LicenceValidityPeriod}
 import uk.gov.hmrc.hec.models.{DateOfBirth, Error, HECTaxCheck, HECTaxCheckCode, HECTaxCheckData, HECTaxCheckMatchRequest, HECTaxCheckMatchResult, Name, TaxSituation}
 import uk.gov.hmrc.hec.services.TaxCheckService
+import uk.gov.hmrc.hec.util.TimeUtils
 import uk.gov.hmrc.http.HeaderCarrier
 
 import java.time.LocalDate
@@ -199,10 +200,12 @@ class TaxCheckControllerSpec extends ControllerSpec {
 
         "the tax check service returns a match result" in {
 
+          val dateTime = TimeUtils.todayByZone()
+
           List[HECTaxCheckMatchResult](
-            Match(companyMatchRequest),
-            NoMatch(companyMatchRequest),
-            Expired(companyMatchRequest)
+            Match(companyMatchRequest, dateTime),
+            NoMatch(companyMatchRequest, dateTime),
+            Expired(companyMatchRequest, dateTime)
           ).foreach { matchResult =>
             withClue(s"For match result '$matchResult': ") {
               mockMatchTaxCheck(companyMatchRequest)(Right(matchResult))

--- a/test/uk/gov/hmrc/hec/controllers/TaxCheckControllerSpec.scala
+++ b/test/uk/gov/hmrc/hec/controllers/TaxCheckControllerSpec.scala
@@ -200,7 +200,7 @@ class TaxCheckControllerSpec extends ControllerSpec {
 
         "the tax check service returns a match result" in {
 
-          val dateTime = TimeUtils.todayByZone()
+          val dateTime = TimeUtils.now()
 
           List[HECTaxCheckMatchResult](
             Match(companyMatchRequest, dateTime),

--- a/test/uk/gov/hmrc/hec/services/TaxCheckServiceImplSpec.scala
+++ b/test/uk/gov/hmrc/hec/services/TaxCheckServiceImplSpec.scala
@@ -197,7 +197,7 @@ class TaxCheckServiceImplSpec extends AnyWordSpec with Matchers with MockFactory
 
         "no tax check exists with the given tax check code" in {
 
-          val dateTime = TimeUtils.todayByZone()
+          val dateTime = TimeUtils.now()
           mockGetTaxCheck(taxCheckCode)(Right(None))
           mockTimeProviderToday(dateTime)
 
@@ -206,7 +206,7 @@ class TaxCheckServiceImplSpec extends AnyWordSpec with Matchers with MockFactory
         }
 
         "the match request is for an individual but the stored tax check is for a company" in {
-          val dateTime = TimeUtils.todayByZone()
+          val dateTime = TimeUtils.now()
           mockGetTaxCheck(taxCheckCode)(Right(Some(storedCompanyTaxCheck)))
           mockTimeProviderToday(dateTime)
 
@@ -215,7 +215,7 @@ class TaxCheckServiceImplSpec extends AnyWordSpec with Matchers with MockFactory
         }
 
         "the match request is for a company but the stored tax check is for an individual" in {
-          val dateTime = TimeUtils.todayByZone()
+          val dateTime = TimeUtils.now()
           mockGetTaxCheck(taxCheckCode)(Right(Some(storedIndividualTaxCheck)))
           mockTimeProviderToday(dateTime)
 
@@ -224,7 +224,7 @@ class TaxCheckServiceImplSpec extends AnyWordSpec with Matchers with MockFactory
         }
 
         "the date of births in the match request and the stored tax check do not match" in {
-          val dateTime = TimeUtils.todayByZone()
+          val dateTime = TimeUtils.now()
           mockGetTaxCheck(taxCheckCode)(Right(Some(storedIndividualTaxCheck)))
           mockTimeProviderToday(dateTime)
 
@@ -234,7 +234,7 @@ class TaxCheckServiceImplSpec extends AnyWordSpec with Matchers with MockFactory
         }
 
         "the CRN's in the match request and the stored tax check do not match" in {
-          val dateTime = TimeUtils.todayByZone()
+          val dateTime = TimeUtils.now()
           mockGetTaxCheck(taxCheckCode)(Right(Some(storedCompanyTaxCheck)))
           mockTimeProviderToday(dateTime)
 
@@ -244,7 +244,7 @@ class TaxCheckServiceImplSpec extends AnyWordSpec with Matchers with MockFactory
         }
 
         "the date of births match but the licence types do not" in {
-          val dateTime = TimeUtils.todayByZone()
+          val dateTime = TimeUtils.now()
           mockGetTaxCheck(taxCheckCode)(Right(Some(storedIndividualTaxCheck)))
           mockTimeProviderToday(dateTime)
 
@@ -254,7 +254,7 @@ class TaxCheckServiceImplSpec extends AnyWordSpec with Matchers with MockFactory
         }
 
         "the CRN's match but the licence types do not" in {
-          val dateTime = TimeUtils.todayByZone()
+          val dateTime = TimeUtils.now()
           mockGetTaxCheck(taxCheckCode)(Right(Some(storedCompanyTaxCheck)))
           mockTimeProviderToday(dateTime)
 
@@ -271,7 +271,7 @@ class TaxCheckServiceImplSpec extends AnyWordSpec with Matchers with MockFactory
           val expiredTaxCheck = storedIndividualTaxCheck.copy(
             expiresAfter = TimeUtils.today().minusMonths(1L)
           )
-          val dateTime        = TimeUtils.todayByZone()
+          val dateTime        = TimeUtils.now()
           mockGetTaxCheck(taxCheckCode)(Right(Some(expiredTaxCheck)))
           mockTimeProviderToday(dateTime)
 
@@ -284,7 +284,7 @@ class TaxCheckServiceImplSpec extends AnyWordSpec with Matchers with MockFactory
             expiresAfter = TimeUtils.today().minusMonths(1L)
           )
 
-          val dateTime = TimeUtils.todayByZone()
+          val dateTime = TimeUtils.now()
           mockGetTaxCheck(taxCheckCode)(Right(Some(expiredTaxCheck)))
           mockTimeProviderToday(dateTime)
 
@@ -297,7 +297,7 @@ class TaxCheckServiceImplSpec extends AnyWordSpec with Matchers with MockFactory
       "return an 'match' result" when {
 
         "all details match for an individual and the stored tax check has not expired" in {
-          val dateTime = TimeUtils.todayByZone()
+          val dateTime = TimeUtils.now()
           mockGetTaxCheck(taxCheckCode)(Right(Some(storedIndividualTaxCheck)))
           mockTimeProviderToday(dateTime)
 
@@ -307,7 +307,7 @@ class TaxCheckServiceImplSpec extends AnyWordSpec with Matchers with MockFactory
 
         "all details match for an company and the stored tax check has not expired" in {
           val taxCheck = storedCompanyTaxCheck.copy(expiresAfter = TimeUtils.today())
-          val dateTime = TimeUtils.todayByZone()
+          val dateTime = TimeUtils.now()
 
           mockTimeProviderToday(dateTime)
           mockGetTaxCheck(taxCheckCode)(Right(Some(taxCheck)))

--- a/test/uk/gov/hmrc/hec/services/TaxCheckServiceImplSpec.scala
+++ b/test/uk/gov/hmrc/hec/services/TaxCheckServiceImplSpec.scala
@@ -31,10 +31,10 @@ import uk.gov.hmrc.hec.models.{DateOfBirth, Error, HECTaxCheck, HECTaxCheckCode,
 import uk.gov.hmrc.hec.models.ids.{CRN, CTUTR, GGCredId, NINO, SAUTR}
 import uk.gov.hmrc.hec.models.licence.{LicenceDetails, LicenceExpiryDate, LicenceTimeTrading, LicenceType, LicenceValidityPeriod}
 import uk.gov.hmrc.hec.repos.HECTaxCheckStore
-import uk.gov.hmrc.hec.util.TimeUtils
+import uk.gov.hmrc.hec.util.{TimeProvider, TimeUtils}
 import uk.gov.hmrc.http.HeaderCarrier
 
-import java.time.LocalDate
+import java.time.{LocalDate, ZonedDateTime}
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
 
@@ -43,12 +43,13 @@ class TaxCheckServiceImplSpec extends AnyWordSpec with Matchers with MockFactory
   val mockTaxCheckCodeGeneratorService = mock[TaxCheckCodeGeneratorService]
   val mockTaxCheckStore                = mock[HECTaxCheckStore]
   val expiresAfter                     = 5.days
+  val mockTimeProvider                 = mock[TimeProvider]
 
   val config = ConfigFactory.parseString(s"""{
       |hec-tax-check.expires-after = ${expiresAfter.toDays} days
       |}""".stripMargin)
 
-  val service = new TaxCheckServiceImpl(mockTaxCheckCodeGeneratorService, mockTaxCheckStore, config)
+  val service = new TaxCheckServiceImpl(mockTaxCheckCodeGeneratorService, mockTimeProvider, mockTaxCheckStore, config)
 
   def mockGenerateTaxCheckCode(taxCheckCode: HECTaxCheckCode) =
     (mockTaxCheckCodeGeneratorService.generateTaxCheckCode _).expects().returning(taxCheckCode)
@@ -64,6 +65,8 @@ class TaxCheckServiceImplSpec extends AnyWordSpec with Matchers with MockFactory
       .get(_: HECTaxCheckCode)(_: HeaderCarrier))
       .expects(taxCheckCode, *)
       .returning(EitherT.fromEither(result))
+
+  def mockTimeProviderToday(d: ZonedDateTime) = (mockTimeProvider.currentDateTime _).expects().returning(d)
 
   implicit val hc: HeaderCarrier = HeaderCarrier()
 
@@ -193,56 +196,71 @@ class TaxCheckServiceImplSpec extends AnyWordSpec with Matchers with MockFactory
       "return a 'no match' result" when {
 
         "no tax check exists with the given tax check code" in {
+
+          val dateTime = TimeUtils.todayByZone()
           mockGetTaxCheck(taxCheckCode)(Right(None))
+          mockTimeProviderToday(dateTime)
 
           val result = service.matchTaxCheck(matchingIndividualMatchRequest)
-          await(result.value) shouldBe Right(NoMatch(matchingIndividualMatchRequest))
+          await(result.value) shouldBe Right(NoMatch(matchingIndividualMatchRequest, dateTime))
         }
 
         "the match request is for an individual but the stored tax check is for a company" in {
+          val dateTime = TimeUtils.todayByZone()
           mockGetTaxCheck(taxCheckCode)(Right(Some(storedCompanyTaxCheck)))
+          mockTimeProviderToday(dateTime)
 
           val result = service.matchTaxCheck(matchingIndividualMatchRequest)
-          await(result.value) shouldBe Right(NoMatch(matchingIndividualMatchRequest))
+          await(result.value) shouldBe Right(NoMatch(matchingIndividualMatchRequest, dateTime))
         }
 
         "the match request is for a company but the stored tax check is for an individual" in {
+          val dateTime = TimeUtils.todayByZone()
           mockGetTaxCheck(taxCheckCode)(Right(Some(storedIndividualTaxCheck)))
+          mockTimeProviderToday(dateTime)
 
           val result = service.matchTaxCheck(matchingCompanyMatchRequest)
-          await(result.value) shouldBe Right(NoMatch(matchingCompanyMatchRequest))
+          await(result.value) shouldBe Right(NoMatch(matchingCompanyMatchRequest, dateTime))
         }
 
         "the date of births in the match request and the stored tax check do not match" in {
+          val dateTime = TimeUtils.todayByZone()
           mockGetTaxCheck(taxCheckCode)(Right(Some(storedIndividualTaxCheck)))
+          mockTimeProviderToday(dateTime)
 
           val matchRequest = matchingIndividualMatchRequest.copy(verifier = Right(incorrectDateOfBirth))
           val result       = service.matchTaxCheck(matchRequest)
-          await(result.value) shouldBe Right(NoMatch(matchRequest))
+          await(result.value) shouldBe Right(NoMatch(matchRequest, dateTime))
         }
 
         "the CRN's in the match request and the stored tax check do not match" in {
+          val dateTime = TimeUtils.todayByZone()
           mockGetTaxCheck(taxCheckCode)(Right(Some(storedCompanyTaxCheck)))
+          mockTimeProviderToday(dateTime)
 
           val matchRequest = matchingCompanyMatchRequest.copy(verifier = Left(incorrectCRN))
           val result       = service.matchTaxCheck(matchRequest)
-          await(result.value) shouldBe Right(NoMatch(matchRequest))
+          await(result.value) shouldBe Right(NoMatch(matchRequest, dateTime))
         }
 
         "the date of births match but the licence types do not" in {
+          val dateTime = TimeUtils.todayByZone()
           mockGetTaxCheck(taxCheckCode)(Right(Some(storedIndividualTaxCheck)))
+          mockTimeProviderToday(dateTime)
 
           val matchRequest = matchingIndividualMatchRequest.copy(licenceType = incorrectLicenceType)
           val result       = service.matchTaxCheck(matchRequest)
-          await(result.value) shouldBe Right(NoMatch(matchRequest))
+          await(result.value) shouldBe Right(NoMatch(matchRequest, dateTime))
         }
 
         "the CRN's match but the licence types do not" in {
+          val dateTime = TimeUtils.todayByZone()
           mockGetTaxCheck(taxCheckCode)(Right(Some(storedCompanyTaxCheck)))
+          mockTimeProviderToday(dateTime)
 
           val matchRequest = matchingCompanyMatchRequest.copy(licenceType = incorrectLicenceType)
           val result       = service.matchTaxCheck(matchRequest)
-          await(result.value) shouldBe Right(NoMatch(matchRequest))
+          await(result.value) shouldBe Right(NoMatch(matchRequest, dateTime))
         }
 
       }
@@ -253,11 +271,12 @@ class TaxCheckServiceImplSpec extends AnyWordSpec with Matchers with MockFactory
           val expiredTaxCheck = storedIndividualTaxCheck.copy(
             expiresAfter = TimeUtils.today().minusMonths(1L)
           )
-
+          val dateTime        = TimeUtils.todayByZone()
           mockGetTaxCheck(taxCheckCode)(Right(Some(expiredTaxCheck)))
+          mockTimeProviderToday(dateTime)
 
           val result = service.matchTaxCheck(matchingIndividualMatchRequest)
-          await(result.value) shouldBe Right(Expired(matchingIndividualMatchRequest))
+          await(result.value) shouldBe Right(Expired(matchingIndividualMatchRequest, dateTime))
         }
 
         "all details match for an company but the stored tax check has expired" in {
@@ -265,10 +284,12 @@ class TaxCheckServiceImplSpec extends AnyWordSpec with Matchers with MockFactory
             expiresAfter = TimeUtils.today().minusMonths(1L)
           )
 
+          val dateTime = TimeUtils.todayByZone()
           mockGetTaxCheck(taxCheckCode)(Right(Some(expiredTaxCheck)))
+          mockTimeProviderToday(dateTime)
 
           val result = service.matchTaxCheck(matchingCompanyMatchRequest)
-          await(result.value) shouldBe Right(Expired(matchingCompanyMatchRequest))
+          await(result.value) shouldBe Right(Expired(matchingCompanyMatchRequest, dateTime))
         }
 
       }
@@ -276,19 +297,23 @@ class TaxCheckServiceImplSpec extends AnyWordSpec with Matchers with MockFactory
       "return an 'match' result" when {
 
         "all details match for an individual and the stored tax check has not expired" in {
+          val dateTime = TimeUtils.todayByZone()
           mockGetTaxCheck(taxCheckCode)(Right(Some(storedIndividualTaxCheck)))
+          mockTimeProviderToday(dateTime)
 
           val result = service.matchTaxCheck(matchingIndividualMatchRequest)
-          await(result.value) shouldBe Right(Match(matchingIndividualMatchRequest))
+          await(result.value) shouldBe Right(Match(matchingIndividualMatchRequest, dateTime))
         }
 
         "all details match for an company and the stored tax check has not expired" in {
           val taxCheck = storedCompanyTaxCheck.copy(expiresAfter = TimeUtils.today())
+          val dateTime = TimeUtils.todayByZone()
 
+          mockTimeProviderToday(dateTime)
           mockGetTaxCheck(taxCheckCode)(Right(Some(taxCheck)))
 
           val result = service.matchTaxCheck(matchingCompanyMatchRequest)
-          await(result.value) shouldBe Right(Match(matchingCompanyMatchRequest))
+          await(result.value) shouldBe Right(Match(matchingCompanyMatchRequest, dateTime))
         }
 
       }


### PR DESCRIPTION
I have added extra field dateTimeChecked in HECTaxCheckMatchResult as for the valid and Expiry tax check page , we need to display the date time at which the check was done against database. Same will be carried forward in LB.