### PR TITLE
HEC-1107 add createDate to tax checks

### DIFF
--- a/app/uk/gov/hmrc/hec/controllers/TaxCheckController.scala
+++ b/app/uk/gov/hmrc/hec/controllers/TaxCheckController.scala
@@ -24,8 +24,8 @@ import uk.gov.hmrc.hec.controllers.actions.AuthenticateActions
 import uk.gov.hmrc.hec.models.ids.GGCredId
 import uk.gov.hmrc.hec.models.{HECTaxCheckData, HECTaxCheckMatchRequest}
 import uk.gov.hmrc.hec.services.TaxCheckService
+import uk.gov.hmrc.hec.util.Logging
 import uk.gov.hmrc.hec.util.Logging.LoggerOps
-import uk.gov.hmrc.hec.util.{Logging, TimeProvider}
 import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -34,7 +34,6 @@ import scala.concurrent.{ExecutionContext, Future}
 class TaxCheckController @Inject() (
   taxCheckService: TaxCheckService,
   authenticate: AuthenticateActions,
-  timeProvider: TimeProvider,
   cc: ControllerComponents
 )(implicit ec: ExecutionContext)
     extends BackendController(cc)
@@ -82,7 +81,7 @@ class TaxCheckController @Inject() (
 
   val getUnexpiredTaxCheckCodes: Action[AnyContent] = authenticate.async { implicit request =>
     taxCheckService
-      .getUnexpiredTaxCheckCodes(GGCredId(request.ggCredId), timeProvider.currentDate)
+      .getUnexpiredTaxCheckCodes(GGCredId(request.ggCredId))
       .fold(
         { e =>
           logger.warn("Error while fetching tax check codes", e)

--- a/app/uk/gov/hmrc/hec/models/HECTaxCheck.scala
+++ b/app/uk/gov/hmrc/hec/models/HECTaxCheck.scala
@@ -18,12 +18,13 @@ package uk.gov.hmrc.hec.models
 
 import play.api.libs.json.{Json, OFormat}
 
-import java.time.LocalDate
+import java.time.{LocalDate, ZonedDateTime}
 
 final case class HECTaxCheck(
   taxCheckData: HECTaxCheckData,
   taxCheckCode: HECTaxCheckCode,
-  expiresAfter: LocalDate
+  expiresAfter: LocalDate,
+  createDate: ZonedDateTime
 )
 
 object HECTaxCheck {

--- a/app/uk/gov/hmrc/hec/models/TaxCheckListItem.scala
+++ b/app/uk/gov/hmrc/hec/models/TaxCheckListItem.scala
@@ -19,12 +19,13 @@ package uk.gov.hmrc.hec.models
 import play.api.libs.json.{Json, OFormat}
 import uk.gov.hmrc.hec.models.licence.LicenceType
 
-import java.time.LocalDate
+import java.time.{LocalDate, ZonedDateTime}
 
 final case class TaxCheckListItem(
   licenceType: LicenceType,
   taxCheckCode: HECTaxCheckCode,
-  expiresAfter: LocalDate
+  expiresAfter: LocalDate,
+  createDate: ZonedDateTime
 )
 
 object TaxCheckListItem {
@@ -33,6 +34,7 @@ object TaxCheckListItem {
   def fromHecTaxCheck(taxCheck: HECTaxCheck): TaxCheckListItem = TaxCheckListItem(
     licenceType = taxCheck.taxCheckData.licenceDetails.licenceType,
     taxCheckCode = taxCheck.taxCheckCode,
-    expiresAfter = taxCheck.expiresAfter
+    expiresAfter = taxCheck.expiresAfter,
+    createDate = taxCheck.createDate
   )
 }

--- a/app/uk/gov/hmrc/hec/services/TaxCheckService.scala
+++ b/app/uk/gov/hmrc/hec/services/TaxCheckService.scala
@@ -26,7 +26,7 @@ import uk.gov.hmrc.hec.models.HECTaxCheckData.{CompanyHECTaxCheckData, Individua
 import uk.gov.hmrc.hec.models.ids.GGCredId
 import uk.gov.hmrc.hec.models.{Error, HECTaxCheck, HECTaxCheckData, HECTaxCheckMatchRequest, HECTaxCheckMatchResult, HECTaxCheckMatchStatus, TaxCheckListItem}
 import uk.gov.hmrc.hec.repos.HECTaxCheckStore
-import uk.gov.hmrc.hec.util.{TimeProvider, TimeUtils}
+import uk.gov.hmrc.hec.util.TimeProvider
 import uk.gov.hmrc.http.HeaderCarrier
 
 import java.time.LocalDate
@@ -64,8 +64,9 @@ class TaxCheckServiceImpl @Inject() (
     taxCheckData: HECTaxCheckData
   )(implicit hc: HeaderCarrier): EitherT[Future, Error, HECTaxCheck] = {
     val taxCheckCode = taxCheckCodeGeneratorService.generateTaxCheckCode()
-    val expiryDate   = TimeUtils.today().plusDays(taxCheckCodeExpiresAfterDays)
-    val taxCheck     = HECTaxCheck(taxCheckData, taxCheckCode, expiryDate)
+    val expiryDate   = timeProvider.currentDate.plusDays(taxCheckCodeExpiresAfterDays)
+    val createDate   = timeProvider.currentDateTime
+    val taxCheck     = HECTaxCheck(taxCheckData, taxCheckCode, expiryDate, createDate)
 
     taxCheckStore.store(taxCheck).map(_ => taxCheck)
   }
@@ -87,7 +88,7 @@ class TaxCheckServiceImpl @Inject() (
     taxCheckMatchRequest: HECTaxCheckMatchRequest,
     storedTaxCheck: HECTaxCheck
   ): HECTaxCheckMatchResult = {
-    lazy val hasExpired = TimeUtils.today().isAfter(storedTaxCheck.expiresAfter)
+    lazy val hasExpired = timeProvider.currentDate.isAfter(storedTaxCheck.expiresAfter)
 
     val applicantVerifierMatches = (taxCheckMatchRequest.verifier, storedTaxCheck.taxCheckData) match {
       case (Right(dateOfBirth), storedIndividualData: IndividualHECTaxCheckData) =>

--- a/app/uk/gov/hmrc/hec/services/TaxCheckService.scala
+++ b/app/uk/gov/hmrc/hec/services/TaxCheckService.scala
@@ -29,7 +29,6 @@ import uk.gov.hmrc.hec.repos.HECTaxCheckStore
 import uk.gov.hmrc.hec.util.TimeProvider
 import uk.gov.hmrc.http.HeaderCarrier
 
-import java.time.LocalDate
 import scala.concurrent.duration.FiniteDuration
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -42,7 +41,7 @@ trait TaxCheckService {
     hc: HeaderCarrier
   ): EitherT[Future, Error, HECTaxCheckMatchResult]
 
-  def getUnexpiredTaxCheckCodes(ggCredId: GGCredId, today: LocalDate)(implicit
+  def getUnexpiredTaxCheckCodes(ggCredId: GGCredId)(implicit
     hc: HeaderCarrier
   ): EitherT[Future, Error, List[TaxCheckListItem]]
 
@@ -113,16 +112,15 @@ class TaxCheckServiceImpl @Inject() (
   }
 
   def getUnexpiredTaxCheckCodes(
-    ggCredId: GGCredId,
-    today: LocalDate
-  )(implicit
-    hc: HeaderCarrier
-  ): EitherT[Future, Error, List[TaxCheckListItem]] =
+    ggCredId: GGCredId
+  )(implicit hc: HeaderCarrier): EitherT[Future, Error, List[TaxCheckListItem]] = {
+    val today = timeProvider.currentDate
     taxCheckStore
       .getTaxCheckCodes(ggCredId)
       .map(
         _.filterNot(item => item.expiresAfter.isBefore(today))
           .map(TaxCheckListItem.fromHecTaxCheck)
       )
+  }
 
 }

--- a/app/uk/gov/hmrc/hec/testonly/models/SaveTaxCheckRequest.scala
+++ b/app/uk/gov/hmrc/hec/testonly/models/SaveTaxCheckRequest.scala
@@ -22,14 +22,15 @@ import uk.gov.hmrc.hec.models.licence.LicenceType
 import uk.gov.hmrc.hec.models.ids.CRN
 import uk.gov.hmrc.hec.models.EitherUtils.eitherFormat
 
-import java.time.LocalDate
+import java.time.{LocalDate, ZonedDateTime}
 import java.time.format.DateTimeFormatter
 
 final case class SaveTaxCheckRequest(
   taxCheckCode: HECTaxCheckCode,
   licenceType: LicenceType,
   verifier: Either[CRN, DateOfBirth],
-  expiresAfter: LocalDate
+  expiresAfter: LocalDate,
+  createDate: ZonedDateTime
 )
 
 object SaveTaxCheckRequest {

--- a/app/uk/gov/hmrc/hec/testonly/services/TaxCheckService.scala
+++ b/app/uk/gov/hmrc/hec/testonly/services/TaxCheckService.scala
@@ -26,6 +26,7 @@ import uk.gov.hmrc.hec.models.licence.{LicenceDetails, LicenceTimeTrading, Licen
 import uk.gov.hmrc.hec.models.{Error, HECTaxCheck, HECTaxCheckCode, HECTaxCheckData, Name, TaxSituation}
 import uk.gov.hmrc.hec.repos.HECTaxCheckStore
 import uk.gov.hmrc.hec.testonly.models.SaveTaxCheckRequest
+import uk.gov.hmrc.hec.util.TimeUtils
 import uk.gov.hmrc.http.HeaderCarrier
 
 import scala.concurrent.Future
@@ -54,7 +55,12 @@ class TaxCheckServiceImpl @Inject() (
     saveTaxCheckRequest: SaveTaxCheckRequest
   )(implicit hc: HeaderCarrier): EitherT[Future, Error, Unit] = {
     val taxCheck =
-      HECTaxCheck(taxCheckData(saveTaxCheckRequest), saveTaxCheckRequest.taxCheckCode, saveTaxCheckRequest.expiresAfter)
+      HECTaxCheck(
+        taxCheckData(saveTaxCheckRequest),
+        saveTaxCheckRequest.taxCheckCode,
+        saveTaxCheckRequest.expiresAfter,
+        TimeUtils.now()
+      )
 
     taxCheckStore.store(taxCheck)
   }

--- a/app/uk/gov/hmrc/hec/testonly/services/TaxCheckService.scala
+++ b/app/uk/gov/hmrc/hec/testonly/services/TaxCheckService.scala
@@ -26,7 +26,6 @@ import uk.gov.hmrc.hec.models.licence.{LicenceDetails, LicenceTimeTrading, Licen
 import uk.gov.hmrc.hec.models.{Error, HECTaxCheck, HECTaxCheckCode, HECTaxCheckData, Name, TaxSituation}
 import uk.gov.hmrc.hec.repos.HECTaxCheckStore
 import uk.gov.hmrc.hec.testonly.models.SaveTaxCheckRequest
-import uk.gov.hmrc.hec.util.TimeUtils
 import uk.gov.hmrc.http.HeaderCarrier
 
 import scala.concurrent.Future
@@ -59,7 +58,7 @@ class TaxCheckServiceImpl @Inject() (
         taxCheckData(saveTaxCheckRequest),
         saveTaxCheckRequest.taxCheckCode,
         saveTaxCheckRequest.expiresAfter,
-        TimeUtils.now()
+        saveTaxCheckRequest.createDate
       )
 
     taxCheckStore.store(taxCheck)

--- a/test/uk/gov/hmrc/hec/controllers/TaxCheckControllerSpec.scala
+++ b/test/uk/gov/hmrc/hec/controllers/TaxCheckControllerSpec.scala
@@ -35,7 +35,7 @@ import uk.gov.hmrc.hec.services.TaxCheckService
 import uk.gov.hmrc.hec.util.TimeUtils
 import uk.gov.hmrc.http.HeaderCarrier
 
-import java.time.LocalDate
+import java.time.{LocalDate, ZonedDateTime}
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
@@ -262,7 +262,8 @@ class TaxCheckControllerSpec extends ControllerSpec with AuthSupport {
             TaxCheckListItem(
               LicenceType.ScrapMetalDealerSite,
               HECTaxCheckCode("some-code"),
-              LocalDate.now()
+              LocalDate.now(),
+              ZonedDateTime.now()
             )
           )
           mockGetValidTaxCheckCodes(ggCredId)(Right(items))

--- a/test/uk/gov/hmrc/hec/controllers/TaxCheckControllerSpec.scala
+++ b/test/uk/gov/hmrc/hec/controllers/TaxCheckControllerSpec.scala
@@ -141,7 +141,7 @@ class TaxCheckControllerSpec extends ControllerSpec with AuthSupport {
         "the tax check has been saved" in {
           val taxCheckCode     = HECTaxCheckCode("code")
           val expiresAfterDate = LocalDate.MIN
-          val taxCheck         = HECTaxCheck(taxCheckData, taxCheckCode, expiresAfterDate)
+          val taxCheck         = HECTaxCheck(taxCheckData, taxCheckCode, expiresAfterDate, TimeUtils.now())
 
           mockSaveTaxCheck(taxCheckData)(Right(taxCheck))
 

--- a/test/uk/gov/hmrc/hec/repos/HECTaxCheckStoreImplSpec.scala
+++ b/test/uk/gov/hmrc/hec/repos/HECTaxCheckStoreImplSpec.scala
@@ -65,7 +65,7 @@ class HECTaxCheckStoreImplSpec extends AnyWordSpec with Matchers with Eventually
 
     val taxCheckCode1 = HECTaxCheckCode("code1")
     val taxCheckCode2 = HECTaxCheckCode("code12")
-    val taxCheck1     = HECTaxCheck(taxCheckData, taxCheckCode1, TimeUtils.today())
+    val taxCheck1     = HECTaxCheck(taxCheckData, taxCheckCode1, TimeUtils.today(), TimeUtils.now())
     val taxCheck2     = taxCheck1.copy(taxCheckCode = taxCheckCode2)
 
     "be able to insert tax checks into mongo, read it back and delete it" in {

--- a/test/uk/gov/hmrc/hec/services/TaxCheckServiceImplSpec.scala
+++ b/test/uk/gov/hmrc/hec/services/TaxCheckServiceImplSpec.scala
@@ -392,15 +392,18 @@ class TaxCheckServiceImplSpec extends AnyWordSpec with Matchers with MockFactory
         val todayItem    = TaxCheckListItem(
           taxCheckToday.taxCheckData.licenceDetails.licenceType,
           taxCheckToday.taxCheckCode,
-          taxCheckToday.expiresAfter
+          taxCheckToday.expiresAfter,
+          taxCheckToday.createDate
         )
         val tomorrowItem = TaxCheckListItem(
           taxCheckTomorrow.taxCheckData.licenceDetails.licenceType,
           taxCheckTomorrow.taxCheckCode,
-          taxCheckTomorrow.expiresAfter
+          taxCheckTomorrow.expiresAfter,
+          taxCheckTomorrow.createDate
         )
 
         mockTimeProviderToday(today)
+        mockTimeProviderNow(now)
         mockGetTaxCheckCodes(ggCredId)(Right(List(taxCheckToday, taxCheckYesterday, taxCheckTomorrow)))
 
         val result = service.getUnexpiredTaxCheckCodes(ggCredId)

--- a/test/uk/gov/hmrc/hec/services/TaxCheckServiceImplSpec.scala
+++ b/test/uk/gov/hmrc/hec/services/TaxCheckServiceImplSpec.scala
@@ -75,6 +75,8 @@ class TaxCheckServiceImplSpec extends AnyWordSpec with Matchers with MockFactory
 
   implicit val hc: HeaderCarrier = HeaderCarrier()
 
+  private val now = TimeUtils.now()
+
   "TaxCheckServiceImpl" when {
 
     "handling requests to save a tax check" must {
@@ -96,7 +98,7 @@ class TaxCheckServiceImplSpec extends AnyWordSpec with Matchers with MockFactory
 
       val expectedExpiryDate = TimeUtils.today().plusDays(expiresAfter.toDays)
       val taxCheckCode       = HECTaxCheckCode("code")
-      val taxCheck           = HECTaxCheck(taxCheckData, taxCheckCode, expectedExpiryDate)
+      val taxCheck           = HECTaxCheck(taxCheckData, taxCheckCode, expectedExpiryDate, now)
 
       "return an error" when {
 
@@ -161,7 +163,8 @@ class TaxCheckServiceImplSpec extends AnyWordSpec with Matchers with MockFactory
             )
           ),
           taxCheckCode,
-          TimeUtils.today().plusMonths(1L)
+          TimeUtils.today().plusMonths(1L),
+          now
         )
 
       val storedCompanyTaxCheck =
@@ -172,7 +175,8 @@ class TaxCheckServiceImplSpec extends AnyWordSpec with Matchers with MockFactory
             CompanyTaxDetails(CTUTR(""))
           ),
           taxCheckCode,
-          TimeUtils.today().plusMonths(1L)
+          TimeUtils.today().plusMonths(1L),
+          now
         )
 
       val matchingIndividualMatchRequest = HECTaxCheckMatchRequest(
@@ -379,9 +383,9 @@ class TaxCheckServiceImplSpec extends AnyWordSpec with Matchers with MockFactory
         val code2 = HECTaxCheckCode("code2")
         val code3 = HECTaxCheckCode("code3")
 
-        val taxCheckToday     = HECTaxCheck(taxCheckData, code1, today)
-        val taxCheckYesterday = HECTaxCheck(taxCheckData, code2, yesterday)
-        val taxCheckTomorrow  = HECTaxCheck(taxCheckData, code3, tomorrow)
+        val taxCheckToday     = HECTaxCheck(taxCheckData, code1, today, now)
+        val taxCheckYesterday = HECTaxCheck(taxCheckData, code2, yesterday, now)
+        val taxCheckTomorrow  = HECTaxCheck(taxCheckData, code3, tomorrow, now)
 
         val todayItem    = TaxCheckListItem(
           taxCheckToday.taxCheckData.licenceDetails.licenceType,

--- a/test/uk/gov/hmrc/hec/testonly/controllers/TaxCheckControllerSpec.scala
+++ b/test/uk/gov/hmrc/hec/testonly/controllers/TaxCheckControllerSpec.scala
@@ -254,7 +254,7 @@ class TaxCheckControllerSpec extends ControllerSpec {
               Some(IncomeDeclared.Yes)
             )
           )
-          val taxCheck     = HECTaxCheck(taxCheckData, validTaxCheckCode, TimeUtils.today())
+          val taxCheck     = HECTaxCheck(taxCheckData, validTaxCheckCode, TimeUtils.today(), TimeUtils.now())
 
           mockGetTaxCheck(validTaxCheckCode)(Right(Some(taxCheck)))
 

--- a/test/uk/gov/hmrc/hec/testonly/controllers/TaxCheckControllerSpec.scala
+++ b/test/uk/gov/hmrc/hec/testonly/controllers/TaxCheckControllerSpec.scala
@@ -100,7 +100,8 @@ class TaxCheckControllerSpec extends ControllerSpec {
            |  "taxCheckCode" : "${r.taxCheckCode.value}",
            |  "licenceType" : "${r.licenceType.toString}",
            |  "verifier" : $verifierJson,
-           |  "expiresAfter" : "${toJsonString(r.expiresAfter)}"
+           |  "expiresAfter" : "${toJsonString(r.expiresAfter)}",
+           |  "createDate" : "${r.createDate}"
            |}
            |""".stripMargin
       }
@@ -113,7 +114,8 @@ class TaxCheckControllerSpec extends ControllerSpec {
           HECTaxCheckCode(invalidTaxCheckCode),
           LicenceType.DriverOfTaxisAndPrivateHires,
           Right(dateOfBirth),
-          TimeUtils.today()
+          TimeUtils.today(),
+          TimeUtils.now()
         )
         val body        = Json.parse(requestJsonString(request))
 
@@ -154,7 +156,8 @@ class TaxCheckControllerSpec extends ControllerSpec {
             validTaxCheckCode,
             LicenceType.DriverOfTaxisAndPrivateHires,
             Right(dateOfBirth),
-            TimeUtils.today()
+            TimeUtils.today(),
+            TimeUtils.now()
           )
           val body        = Json.parse(requestJsonString(request))
 
@@ -175,7 +178,8 @@ class TaxCheckControllerSpec extends ControllerSpec {
             validTaxCheckCode,
             LicenceType.DriverOfTaxisAndPrivateHires,
             Right(dateOfBirth),
-            TimeUtils.today()
+            TimeUtils.today(),
+            TimeUtils.now()
           )
           val body        = Json.parse(requestJsonString(request))
 
@@ -191,7 +195,8 @@ class TaxCheckControllerSpec extends ControllerSpec {
             validTaxCheckCode,
             LicenceType.DriverOfTaxisAndPrivateHires,
             Left(crn),
-            TimeUtils.today()
+            TimeUtils.today(),
+            TimeUtils.now()
           )
           val body    = Json.parse(requestJsonString(request))
 

--- a/test/uk/gov/hmrc/hec/testonly/services/TaxCheckServiceImplSpec.scala
+++ b/test/uk/gov/hmrc/hec/testonly/services/TaxCheckServiceImplSpec.scala
@@ -68,6 +68,8 @@ class TaxCheckServiceImplSpec extends AnyWordSpec with Matchers with MockFactory
 
   implicit val hc: HeaderCarrier = HeaderCarrier()
 
+  private val now = TimeUtils.now()
+
   "TaxCheckServiceImpl" when {
 
     "handling requests to save a tax check" must {
@@ -87,7 +89,8 @@ class TaxCheckServiceImplSpec extends AnyWordSpec with Matchers with MockFactory
           val taxCheck = HECTaxCheck(
             service.taxCheckData(request),
             request.taxCheckCode,
-            request.expiresAfter
+            request.expiresAfter,
+            now
           )
 
           inSequence {
@@ -107,7 +110,8 @@ class TaxCheckServiceImplSpec extends AnyWordSpec with Matchers with MockFactory
           val taxCheck = HECTaxCheck(
             service.taxCheckData(request),
             request.taxCheckCode,
-            request.expiresAfter
+            request.expiresAfter,
+            now
           )
 
           inSequence {
@@ -123,7 +127,8 @@ class TaxCheckServiceImplSpec extends AnyWordSpec with Matchers with MockFactory
           val taxCheck = HECTaxCheck(
             service.taxCheckData(request),
             request.taxCheckCode,
-            request.expiresAfter
+            request.expiresAfter,
+            now
           )
 
           inSequence {
@@ -166,7 +171,7 @@ class TaxCheckServiceImplSpec extends AnyWordSpec with Matchers with MockFactory
               Some(IncomeDeclared.Yes)
             )
           )
-          val taxCheck     = HECTaxCheck(taxCheckData, taxCheckCode, TimeUtils.today())
+          val taxCheck     = HECTaxCheck(taxCheckData, taxCheckCode, TimeUtils.today(), now)
 
           mockGetTaxCheck(taxCheckCode)(Right(Some(taxCheck)))
 


### PR DESCRIPTION
Addresses the bit about being able to sort tax checks by timestamp for the listing page as specified in this ticket - https://jira.tools.tax.service.gov.uk/browse/HEC-1113

Decided to add a new field instead of using the `modifiedDetails.createdAt` to remove dependency on upstream library (it returns a Joda date) and also makes it easy for testing