### PR TITLE
Wait for db insert to complete in tests

### DIFF
--- a/test/uk/gov/hmrc/hec/repos/HECTaxCheckStoreImplSpec.scala
+++ b/test/uk/gov/hmrc/hec/repos/HECTaxCheckStoreImplSpec.scala
@@ -165,7 +165,7 @@ class HECTaxCheckStoreImplSpec extends AnyWordSpec with Matchers with Eventually
                                    |}""".stripMargin)
 
       // insert invalid data
-      taxCheckStore.put(taxCheckCode)(DataKey("hec-tax-check"), invalidData)
+      await(taxCheckStore.put(taxCheckCode)(DataKey("hec-tax-check"), invalidData))
       await(taxCheckStore.getTaxCheckCodes(GGCredId(ggCredId)).value).isLeft shouldBe true
     }
 
@@ -198,8 +198,7 @@ class HECTaxCheckStoreImplSpec extends AnyWordSpec with Matchers with Eventually
                                       |}""".stripMargin)
 
       // insert invalid data
-
-      taxCheckStore.put(taxCheckCode)(DataKey("hec-tax-check"), invalidData)
+      await(taxCheckStore.put(taxCheckCode)(DataKey("hec-tax-check"), invalidData))
       await(taxCheckStore.getAllTaxCheckCodesByExtractedStatus(false).value).isLeft shouldBe true
     }
   }


### PR DESCRIPTION
In local runs of `HECTaxCheckStoreImplSpec` meant the tests `return an error when data can't be parsed when fetching tax check codes based on GGCredId/isExtracted` failed randomly. This was due to not waiting on the insert of data to the database.