### PR TITLE
HEC-1187 add ggCredid for testOnly request

### DIFF
--- a/app/uk/gov/hmrc/hec/testonly/models/SaveTaxCheckRequest.scala
+++ b/app/uk/gov/hmrc/hec/testonly/models/SaveTaxCheckRequest.scala
@@ -17,15 +17,17 @@
 package uk.gov.hmrc.hec.testonly.models
 
 import play.api.libs.json.{Json, Reads}
-import uk.gov.hmrc.hec.models.ids.CRN
+import uk.gov.hmrc.hec.models.ids.{CRN, GGCredId}
 import uk.gov.hmrc.hec.models.licence.LicenceType
 import uk.gov.hmrc.hec.models.{DateOfBirth, HECTaxCheckCode}
 import uk.gov.hmrc.hec.models.EitherUtils.eitherFormat
+
 import java.time.format.DateTimeFormatter
 import java.time.{LocalDate, ZonedDateTime}
 
 final case class SaveTaxCheckRequest(
   taxCheckCode: HECTaxCheckCode,
+  ggCredId: GGCredId,
   licenceType: LicenceType,
   verifier: Either[CRN, DateOfBirth],
   expiresAfter: LocalDate,

--- a/app/uk/gov/hmrc/hec/testonly/services/TaxCheckService.scala
+++ b/app/uk/gov/hmrc/hec/testonly/services/TaxCheckService.scala
@@ -21,7 +21,7 @@ import com.google.inject.{ImplementedBy, Inject, Singleton}
 import uk.gov.hmrc.hec.models.ApplicantDetails.{CompanyApplicantDetails, IndividualApplicantDetails}
 import uk.gov.hmrc.hec.models.HECTaxCheckData.{CompanyHECTaxCheckData, IndividualHECTaxCheckData}
 import uk.gov.hmrc.hec.models.TaxDetails.{CompanyTaxDetails, IndividualTaxDetails}
-import uk.gov.hmrc.hec.models.ids.{CTUTR, GGCredId, NINO}
+import uk.gov.hmrc.hec.models.ids.{CTUTR, NINO}
 import uk.gov.hmrc.hec.models.licence.{LicenceDetails, LicenceTimeTrading, LicenceValidityPeriod}
 import uk.gov.hmrc.hec.models.{Error, HECTaxCheck, HECTaxCheckCode, HECTaxCheckData, Name, TaxSituation}
 import uk.gov.hmrc.hec.repos.HECTaxCheckStore
@@ -85,7 +85,7 @@ class TaxCheckServiceImpl @Inject() (
       LicenceValidityPeriod.UpToOneYear
     )
 
-    val ggCredId = GGCredId("testCredId")
+    val ggCredId = saveTaxCheckRequest.ggCredId
 
     saveTaxCheckRequest.verifier match {
       case Left(crn) =>

--- a/test/uk/gov/hmrc/hec/testonly/controllers/TaxCheckControllerSpec.scala
+++ b/test/uk/gov/hmrc/hec/testonly/controllers/TaxCheckControllerSpec.scala
@@ -102,6 +102,7 @@ class TaxCheckControllerSpec extends ControllerSpec {
         s"""
            |{
            |  "taxCheckCode" : "${r.taxCheckCode.value}",
+           |  "ggCredId" : "${r.ggCredId.value}",
            |  "licenceType" : "${r.licenceType.toString}",
            |  "verifier" : $verifierJson,
            |  "expiresAfter" : "${toJsonString(r.expiresAfter)}",
@@ -118,6 +119,7 @@ class TaxCheckControllerSpec extends ControllerSpec {
         val dateOfBirth = DateOfBirth(TimeUtils.today())
         val request     = SaveTaxCheckRequest(
           HECTaxCheckCode(invalidTaxCheckCode),
+          GGCredId("AB123"),
           LicenceType.DriverOfTaxisAndPrivateHires,
           Right(dateOfBirth),
           TimeUtils.today(),
@@ -162,6 +164,7 @@ class TaxCheckControllerSpec extends ControllerSpec {
           val dateOfBirth = DateOfBirth(TimeUtils.today())
           val request     = SaveTaxCheckRequest(
             taxCheckCode = validTaxCheckCode,
+            GGCredId("AB123"),
             licenceType = LicenceType.DriverOfTaxisAndPrivateHires,
             verifier = Right(dateOfBirth),
             expiresAfter = TimeUtils.today(),
@@ -170,7 +173,6 @@ class TaxCheckControllerSpec extends ControllerSpec {
             isExtracted = false
           )
           val body        = Json.parse(requestJsonString(request))
-          println(" body is ::" + body.toString())
 
           mockSaveTaxCheck(request)(Left(Error("")))
 
@@ -187,6 +189,7 @@ class TaxCheckControllerSpec extends ControllerSpec {
           val dateOfBirth = DateOfBirth(TimeUtils.today())
           val request     = SaveTaxCheckRequest(
             validTaxCheckCode,
+            GGCredId("AB123"),
             LicenceType.DriverOfTaxisAndPrivateHires,
             Right(dateOfBirth),
             TimeUtils.today(),
@@ -206,6 +209,7 @@ class TaxCheckControllerSpec extends ControllerSpec {
           val crn     = CRN("1234567895")
           val request = SaveTaxCheckRequest(
             validTaxCheckCode,
+            GGCredId("AB123"),
             LicenceType.DriverOfTaxisAndPrivateHires,
             Left(crn),
             TimeUtils.today(),

--- a/test/uk/gov/hmrc/hec/testonly/services/TaxCheckServiceImplSpec.scala
+++ b/test/uk/gov/hmrc/hec/testonly/services/TaxCheckServiceImplSpec.scala
@@ -84,6 +84,7 @@ class TaxCheckServiceImplSpec extends AnyWordSpec with Matchers with MockFactory
       def saveTaxCheckRequest(verifier: Either[CRN, DateOfBirth]) =
         SaveTaxCheckRequest(
           HECTaxCheckCode("ABCDEF234"),
+          GGCredId("AB123"),
           LicenceType.ScrapMetalDealerSite,
           verifier,
           today,


### PR DESCRIPTION
QA needs ggCrdId now as a part of the request they make to insert hec tax check code. This PR i to add ggCredId to the request.