### PR TITLE
Make IndividualApplicantDetails.ggCredId optional

### DIFF
--- a/app/uk/gov/hmrc/hec/models/ApplicantDetails.scala
+++ b/app/uk/gov/hmrc/hec/models/ApplicantDetails.scala
@@ -24,7 +24,7 @@ sealed trait ApplicantDetails extends Product with Serializable
 object ApplicantDetails {
 
   final case class IndividualApplicantDetails(
-    ggCredId: GGCredId,
+    ggCredId: Option[GGCredId],
     name: Name,
     dateOfBirth: DateOfBirth
   ) extends ApplicantDetails

--- a/app/uk/gov/hmrc/hec/services/FileCreationService.scala
+++ b/app/uk/gov/hmrc/hec/services/FileCreationService.scala
@@ -169,7 +169,7 @@ class FileCreationServiceImpl @Inject() (timeProvider: TimeProvider) extends Fil
           val taxSituationMap = taxSituationMapping(i.taxDetails.taxSituation)
           val saStatusMap     = saStatusMapping(i.taxDetails.saStatusResponse.map(_.status))
           HECTaxCheckFileBody(
-            ggCredID = Some(i.applicantDetails.ggCredId.value),
+            ggCredID = i.applicantDetails.ggCredId.map(_.value),
             nino = Some(i.taxDetails.nino.value),
             firstName = Some(i.applicantDetails.name.firstName),
             lastName = Some(i.applicantDetails.name.lastName),

--- a/app/uk/gov/hmrc/hec/testonly/services/TaxCheckService.scala
+++ b/app/uk/gov/hmrc/hec/testonly/services/TaxCheckService.scala
@@ -115,7 +115,7 @@ class TaxCheckServiceImpl @Inject() (
         )
 
       case Right(dob) =>
-        val individualDetails    = IndividualApplicantDetails(ggCredId, Name("TestFirst", "TestLast"), dob)
+        val individualDetails    = IndividualApplicantDetails(Some(ggCredId), Name("TestFirst", "TestLast"), dob)
         val individualTaxDetails = IndividualTaxDetails(NINO("AB123456C"), None, TaxSituation.PAYE, None, None)
         IndividualHECTaxCheckData(
           individualDetails,

--- a/test/uk/gov/hmrc/hec/controllers/TaxCheckControllerSpec.scala
+++ b/test/uk/gov/hmrc/hec/controllers/TaxCheckControllerSpec.scala
@@ -89,7 +89,7 @@ class TaxCheckControllerSpec extends ControllerSpec with AuthSupport {
       }
 
       val taxCheckDataIndividual: HECTaxCheckData = IndividualHECTaxCheckData(
-        IndividualApplicantDetails(GGCredId(""), Name("", ""), DateOfBirth(LocalDate.now())),
+        IndividualApplicantDetails(Some(GGCredId("")), Name("", ""), DateOfBirth(LocalDate.now())),
         LicenceDetails(
           LicenceType.ScrapMetalDealerSite,
           LicenceTimeTrading.EightYearsOrMore,

--- a/test/uk/gov/hmrc/hec/models/HECTaxCheckDataSpec.scala
+++ b/test/uk/gov/hmrc/hec/models/HECTaxCheckDataSpec.scala
@@ -39,7 +39,7 @@ class HECTaxCheckDataSpec extends AnyWordSpec with Matchers {
       val individualTaxCheckData: HECTaxCheckData =
         IndividualHECTaxCheckData(
           IndividualApplicantDetails(
-            GGCredId("ggCredId"),
+            Some(GGCredId("ggCredId")),
             Name("first", "last"),
             DateOfBirth(dateOfBirth)
           ),

--- a/test/uk/gov/hmrc/hec/services/FileCreationServiceSpec.scala
+++ b/test/uk/gov/hmrc/hec/services/FileCreationServiceSpec.scala
@@ -140,7 +140,7 @@ class FileCreationServiceSpec extends AnyWordSpec with Matchers with MockFactory
 
             val individualApplicantDetails =
               IndividualApplicantDetails(
-                GGCredId("AB123"),
+                Some(GGCredId("AB123")),
                 Name("Karen", "mcFie"),
                 DateOfBirth(LocalDate.of(1922, 12, 1))
               )

--- a/test/uk/gov/hmrc/hec/services/TaxCheckServiceImplSpec.scala
+++ b/test/uk/gov/hmrc/hec/services/TaxCheckServiceImplSpec.scala
@@ -105,7 +105,7 @@ class TaxCheckServiceImplSpec extends AnyWordSpec with Matchers with MockFactory
     "handling requests to save a tax check" must {
 
       val taxCheckData = IndividualHECTaxCheckData(
-        IndividualApplicantDetails(GGCredId(""), Name("", ""), DateOfBirth(LocalDate.now())),
+        IndividualApplicantDetails(Some(GGCredId("")), Name("", ""), DateOfBirth(LocalDate.now())),
         LicenceDetails(
           LicenceType.ScrapMetalDealerSite,
           LicenceTimeTrading.EightYearsOrMore,
@@ -196,7 +196,7 @@ class TaxCheckServiceImplSpec extends AnyWordSpec with Matchers with MockFactory
       val storedIndividualTaxCheck =
         HECTaxCheck(
           IndividualHECTaxCheckData(
-            IndividualApplicantDetails(GGCredId(""), Name("", ""), storedDateOfBirth),
+            IndividualApplicantDetails(Some(GGCredId("")), Name("", ""), storedDateOfBirth),
             storedLicenceDetails,
             IndividualTaxDetails(
               NINO(""),

--- a/test/uk/gov/hmrc/hec/testonly/controllers/TaxCheckControllerSpec.scala
+++ b/test/uk/gov/hmrc/hec/testonly/controllers/TaxCheckControllerSpec.scala
@@ -270,7 +270,7 @@ class TaxCheckControllerSpec extends ControllerSpec {
 
         "a tax check was found" in {
           val taxCheckData = IndividualHECTaxCheckData(
-            IndividualApplicantDetails(GGCredId(""), Name("", ""), DateOfBirth(LocalDate.now())),
+            IndividualApplicantDetails(Some(GGCredId("")), Name("", ""), DateOfBirth(LocalDate.now())),
             LicenceDetails(
               LicenceType.ScrapMetalDealerSite,
               LicenceTimeTrading.EightYearsOrMore,

--- a/test/uk/gov/hmrc/hec/testonly/services/TaxCheckServiceImplSpec.scala
+++ b/test/uk/gov/hmrc/hec/testonly/services/TaxCheckServiceImplSpec.scala
@@ -182,7 +182,7 @@ class TaxCheckServiceImplSpec extends AnyWordSpec with Matchers with MockFactory
 
         "a tax check is found" in {
           val taxCheckData = IndividualHECTaxCheckData(
-            IndividualApplicantDetails(GGCredId(""), Name("", ""), DateOfBirth(LocalDate.now())),
+            IndividualApplicantDetails(Some(GGCredId("")), Name("", ""), DateOfBirth(LocalDate.now())),
             LicenceDetails(
               LicenceType.ScrapMetalDealerSite,
               LicenceTimeTrading.EightYearsOrMore,


### PR DESCRIPTION
Stride journeys do not have `GGCredId` and so this needs to be optional in the backend.