### PR TITLE
Hec 1420 rity

### DIFF
--- a/app/uk/gov/hmrc/hec/models/TaxDetails.scala
+++ b/app/uk/gov/hmrc/hec/models/TaxDetails.scala
@@ -29,7 +29,7 @@ object TaxDetails {
     taxSituation: TaxSituation,
     saIncomeDeclared: Option[YesNoAnswer],
     saStatusResponse: Option[SAStatusResponse],
-    relevantIncomeTaxYear: Int
+    relevantIncomeTaxYear: TaxYear
   ) extends TaxDetails
 
   final case class CompanyTaxDetails(

--- a/app/uk/gov/hmrc/hec/models/TaxDetails.scala
+++ b/app/uk/gov/hmrc/hec/models/TaxDetails.scala
@@ -28,7 +28,8 @@ object TaxDetails {
     sautr: Option[SAUTR],
     taxSituation: TaxSituation,
     saIncomeDeclared: Option[YesNoAnswer],
-    saStatusResponse: Option[SAStatusResponse]
+    saStatusResponse: Option[SAStatusResponse],
+    relevantIncomeTaxYear: Int
   ) extends TaxDetails
 
   final case class CompanyTaxDetails(

--- a/app/uk/gov/hmrc/hec/services/FileCreationService.scala
+++ b/app/uk/gov/hmrc/hec/services/FileCreationService.scala
@@ -16,6 +16,7 @@
 
 package uk.gov.hmrc.hec.services
 
+import cats.implicits.catsSyntaxOptionId
 import cats.syntax.eq._
 import com.google.inject.{ImplementedBy, Inject}
 import uk.gov.hmrc.hec.models.CorrectiveAction._
@@ -182,7 +183,7 @@ class FileCreationServiceImpl @Inject() (timeProvider: TimeProvider) extends Fil
             notChargeable = taxSituationMap.NotChargeable,
             PAYE = taxSituationMap.PAYE,
             SA = taxSituationMap.SA,
-            incomeTaxYear = i.taxDetails.saStatusResponse.map(_.taxYear.startYear + 1),
+            incomeTaxYear = i.taxDetails.relevantIncomeTaxYear.some,
             returnReceived = saStatusMap.returnReceived,
             noticeToFile = saStatusMap.noticeToFileIssued,
             taxComplianceDeclaration = saStatusMap.returnReceived,

--- a/app/uk/gov/hmrc/hec/services/FileCreationService.scala
+++ b/app/uk/gov/hmrc/hec/services/FileCreationService.scala
@@ -183,7 +183,7 @@ class FileCreationServiceImpl @Inject() (timeProvider: TimeProvider) extends Fil
             notChargeable = taxSituationMap.NotChargeable,
             PAYE = taxSituationMap.PAYE,
             SA = taxSituationMap.SA,
-            incomeTaxYear = i.taxDetails.relevantIncomeTaxYear.startYear.some,
+            incomeTaxYear = (i.taxDetails.relevantIncomeTaxYear.startYear + 1).some,
             returnReceived = saStatusMap.returnReceived,
             noticeToFile = saStatusMap.noticeToFileIssued,
             taxComplianceDeclaration = saStatusMap.returnReceived,

--- a/app/uk/gov/hmrc/hec/services/FileCreationService.scala
+++ b/app/uk/gov/hmrc/hec/services/FileCreationService.scala
@@ -183,7 +183,7 @@ class FileCreationServiceImpl @Inject() (timeProvider: TimeProvider) extends Fil
             notChargeable = taxSituationMap.NotChargeable,
             PAYE = taxSituationMap.PAYE,
             SA = taxSituationMap.SA,
-            incomeTaxYear = i.taxDetails.relevantIncomeTaxYear.some,
+            incomeTaxYear = i.taxDetails.relevantIncomeTaxYear.startYear.some,
             returnReceived = saStatusMap.returnReceived,
             noticeToFile = saStatusMap.noticeToFileIssued,
             taxComplianceDeclaration = saStatusMap.returnReceived,

--- a/app/uk/gov/hmrc/hec/testonly/models/SaveTaxCheckRequest.scala
+++ b/app/uk/gov/hmrc/hec/testonly/models/SaveTaxCheckRequest.scala
@@ -35,7 +35,7 @@ final case class SaveTaxCheckRequest(
   taxCheckStartDateTime: ZonedDateTime,
   isExtracted: Boolean,
   source: HECTaxCheckSource,
-  relevantIncomeTaxYear: TaxYear
+  relevantIncomeTaxYear: Option[TaxYear]
 )
 
 object SaveTaxCheckRequest {

--- a/app/uk/gov/hmrc/hec/testonly/models/SaveTaxCheckRequest.scala
+++ b/app/uk/gov/hmrc/hec/testonly/models/SaveTaxCheckRequest.scala
@@ -19,8 +19,9 @@ package uk.gov.hmrc.hec.testonly.models
 import play.api.libs.json.{Json, Reads}
 import uk.gov.hmrc.hec.models.ids.{CRN, GGCredId}
 import uk.gov.hmrc.hec.models.licence.LicenceType
-import uk.gov.hmrc.hec.models.{DateOfBirth, HECTaxCheckCode, HECTaxCheckSource}
+import uk.gov.hmrc.hec.models.{DateOfBirth, HECTaxCheckCode, HECTaxCheckSource, TaxYear}
 import uk.gov.hmrc.hec.models.EitherUtils.eitherFormat
+
 import java.time.format.DateTimeFormatter
 import java.time.{LocalDate, ZonedDateTime}
 
@@ -34,7 +35,7 @@ final case class SaveTaxCheckRequest(
   taxCheckStartDateTime: ZonedDateTime,
   isExtracted: Boolean,
   source: HECTaxCheckSource,
-  relevantIncomeTaxYear: Int
+  relevantIncomeTaxYear: TaxYear
 )
 
 object SaveTaxCheckRequest {

--- a/app/uk/gov/hmrc/hec/testonly/models/SaveTaxCheckRequest.scala
+++ b/app/uk/gov/hmrc/hec/testonly/models/SaveTaxCheckRequest.scala
@@ -33,7 +33,8 @@ final case class SaveTaxCheckRequest(
   createDate: ZonedDateTime,
   taxCheckStartDateTime: ZonedDateTime,
   isExtracted: Boolean,
-  source: HECTaxCheckSource
+  source: HECTaxCheckSource,
+  relevantIncomeTaxYear: Int
 )
 
 object SaveTaxCheckRequest {

--- a/app/uk/gov/hmrc/hec/testonly/services/TaxCheckService.scala
+++ b/app/uk/gov/hmrc/hec/testonly/services/TaxCheckService.scala
@@ -116,7 +116,14 @@ class TaxCheckServiceImpl @Inject() (
 
       case Right(dob) =>
         val individualDetails    = IndividualApplicantDetails(Some(ggCredId), Name("TestFirst", "TestLast"), dob)
-        val individualTaxDetails = IndividualTaxDetails(NINO("AB123456C"), None, TaxSituation.PAYE, None, None)
+        val individualTaxDetails = IndividualTaxDetails(
+          NINO("AB123456C"),
+          None,
+          TaxSituation.PAYE,
+          None,
+          None,
+          saveTaxCheckRequest.relevantIncomeTaxYear
+        )
         IndividualHECTaxCheckData(
           individualDetails,
           licenceDetails,

--- a/test/uk/gov/hmrc/hec/actors/TimeCalculatorSpec.scala
+++ b/test/uk/gov/hmrc/hec/actors/TimeCalculatorSpec.scala
@@ -20,7 +20,6 @@ import org.scalamock.scalatest.MockFactory
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import uk.gov.hmrc.hec.util.TimeProvider
-
 import java.time.{LocalTime, ZoneId}
 import scala.concurrent.duration._
 

--- a/test/uk/gov/hmrc/hec/controllers/TaxCheckControllerSpec.scala
+++ b/test/uk/gov/hmrc/hec/controllers/TaxCheckControllerSpec.scala
@@ -100,7 +100,8 @@ class TaxCheckControllerSpec extends ControllerSpec with AuthSupport {
           Some(SAUTR("")),
           TaxSituation.PAYE,
           None,
-          None
+          None,
+          2021
         ),
         taxCheckStartDateTime,
         HECTaxCheckSource.Digital

--- a/test/uk/gov/hmrc/hec/controllers/TaxCheckControllerSpec.scala
+++ b/test/uk/gov/hmrc/hec/controllers/TaxCheckControllerSpec.scala
@@ -31,7 +31,7 @@ import uk.gov.hmrc.hec.models.HECTaxCheckData.{CompanyHECTaxCheckData, Individua
 import uk.gov.hmrc.hec.models.TaxDetails.{CompanyTaxDetails, IndividualTaxDetails}
 import uk.gov.hmrc.hec.models.ids._
 import uk.gov.hmrc.hec.models.licence.{LicenceDetails, LicenceTimeTrading, LicenceType, LicenceValidityPeriod}
-import uk.gov.hmrc.hec.models.{CTAccountingPeriod, CTStatus, CTStatusResponse, CompanyHouseName, DateOfBirth, Error, HECTaxCheck, HECTaxCheckCode, HECTaxCheckData, HECTaxCheckMatchRequest, HECTaxCheckMatchResult, HECTaxCheckMatchStatus, HECTaxCheckSource, Name, TaxCheckListItem, TaxSituation, YesNoAnswer}
+import uk.gov.hmrc.hec.models.{CTAccountingPeriod, CTStatus, CTStatusResponse, CompanyHouseName, DateOfBirth, Error, HECTaxCheck, HECTaxCheckCode, HECTaxCheckData, HECTaxCheckMatchRequest, HECTaxCheckMatchResult, HECTaxCheckMatchStatus, HECTaxCheckSource, Name, TaxCheckListItem, TaxSituation, TaxYear, YesNoAnswer}
 import uk.gov.hmrc.hec.services.TaxCheckService
 import uk.gov.hmrc.hec.util.TimeUtils
 import uk.gov.hmrc.http.HeaderCarrier
@@ -101,7 +101,7 @@ class TaxCheckControllerSpec extends ControllerSpec with AuthSupport {
           TaxSituation.PAYE,
           None,
           None,
-          2021
+          TaxYear(2021)
         ),
         taxCheckStartDateTime,
         HECTaxCheckSource.Digital

--- a/test/uk/gov/hmrc/hec/models/HECTaxCheckDataSpec.scala
+++ b/test/uk/gov/hmrc/hec/models/HECTaxCheckDataSpec.scala
@@ -53,7 +53,8 @@ class HECTaxCheckDataSpec extends AnyWordSpec with Matchers {
             Some(SAUTR("utr")),
             TaxSituation.SA,
             Some(YesNoAnswer.Yes),
-            None
+            None,
+            2021
           ),
           taxCheckStartDateTime,
           HECTaxCheckSource.Digital
@@ -77,7 +78,8 @@ class HECTaxCheckDataSpec extends AnyWordSpec with Matchers {
                                          |    "nino":"nino",
                                          |    "sautr":"utr",
                                          |    "taxSituation":"SA",
-                                         |    "saIncomeDeclared":"Yes"
+                                         |    "saIncomeDeclared":"Yes",
+                                         |    "relevantIncomeTaxYear": 2021
                                          | },
                                          | "taxCheckStartDateTime" : "2021-10-09T09:12:34+01:00[Europe/London]",
                                          | "type":"Individual",

--- a/test/uk/gov/hmrc/hec/models/HECTaxCheckDataSpec.scala
+++ b/test/uk/gov/hmrc/hec/models/HECTaxCheckDataSpec.scala
@@ -54,7 +54,7 @@ class HECTaxCheckDataSpec extends AnyWordSpec with Matchers {
             TaxSituation.SA,
             Some(YesNoAnswer.Yes),
             None,
-            2021
+            TaxYear(2021)
           ),
           taxCheckStartDateTime,
           HECTaxCheckSource.Digital

--- a/test/uk/gov/hmrc/hec/repos/MongoSupportSpec.scala
+++ b/test/uk/gov/hmrc/hec/repos/MongoSupportSpec.scala
@@ -16,14 +16,12 @@
 
 package uk.gov.hmrc.hec.repos
 
+import org.scalatest.BeforeAndAfterAll
 import org.scalatest.matchers.should.Matchers
-import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach, Suite}
-import uk.gov.hmrc.mongo.test.MongoSupport
+import org.scalatest.wordspec.AnyWordSpec
+import uk.gov.hmrc.mongo.test.CleanMongoCollectionSupport
 
-trait MongoSupportSpec extends MongoSupport with BeforeAndAfterEach with BeforeAndAfterAll { this: Suite with Matchers ⇒
-
-  abstract override def beforeEach(): Unit =
-    super.beforeEach()
+trait MongoSupportSpec extends AnyWordSpec with Matchers with CleanMongoCollectionSupport with BeforeAndAfterAll {
 
   abstract override def afterAll(): Unit = {
     super.afterAll()

--- a/test/uk/gov/hmrc/hec/repos/MongoSupportSpec.scala
+++ b/test/uk/gov/hmrc/hec/repos/MongoSupportSpec.scala
@@ -23,7 +23,7 @@ import uk.gov.hmrc.mongo.test.MongoSupport
 trait MongoSupportSpec extends MongoSupport with BeforeAndAfterEach with BeforeAndAfterAll { this: Suite with Matchers ⇒
 
   abstract override def beforeEach(): Unit =
-    dropDatabase()
+    super.beforeEach()
 
   abstract override def afterAll(): Unit = {
     super.afterAll()

--- a/test/uk/gov/hmrc/hec/repos/MongoSupportSpec.scala
+++ b/test/uk/gov/hmrc/hec/repos/MongoSupportSpec.scala
@@ -22,10 +22,8 @@ import uk.gov.hmrc.mongo.test.MongoSupport
 
 trait MongoSupportSpec extends MongoSupport with BeforeAndAfterEach with BeforeAndAfterAll { this: Suite with Matchers ⇒
 
-  abstract override def beforeEach(): Unit = {
-    super.beforeEach()
+  abstract override def beforeEach(): Unit =
     dropDatabase()
-  }
 
   abstract override def afterAll(): Unit = {
     super.afterAll()

--- a/test/uk/gov/hmrc/hec/services/FileCreationServiceSpec.scala
+++ b/test/uk/gov/hmrc/hec/services/FileCreationServiceSpec.scala
@@ -151,7 +151,8 @@ class FileCreationServiceSpec extends AnyWordSpec with Matchers with MockFactory
                 Some(SAUTR("1234567")),
                 taxSituation,
                 Some(YesNoAnswer.Yes),
-                saStatusResponse
+                saStatusResponse,
+                2022
               )
 
             def createIndividualHecTaxCheck(

--- a/test/uk/gov/hmrc/hec/services/FileCreationServiceSpec.scala
+++ b/test/uk/gov/hmrc/hec/services/FileCreationServiceSpec.scala
@@ -152,7 +152,7 @@ class FileCreationServiceSpec extends AnyWordSpec with Matchers with MockFactory
                 taxSituation,
                 Some(YesNoAnswer.Yes),
                 saStatusResponse,
-                TaxYear(2022)
+                TaxYear(2021)
               )
 
             def createIndividualHecTaxCheck(

--- a/test/uk/gov/hmrc/hec/services/FileCreationServiceSpec.scala
+++ b/test/uk/gov/hmrc/hec/services/FileCreationServiceSpec.scala
@@ -152,7 +152,7 @@ class FileCreationServiceSpec extends AnyWordSpec with Matchers with MockFactory
                 taxSituation,
                 Some(YesNoAnswer.Yes),
                 saStatusResponse,
-                2022
+                TaxYear(2022)
               )
 
             def createIndividualHecTaxCheck(

--- a/test/uk/gov/hmrc/hec/services/TaxCheckServiceImplSpec.scala
+++ b/test/uk/gov/hmrc/hec/services/TaxCheckServiceImplSpec.scala
@@ -29,7 +29,7 @@ import uk.gov.hmrc.hec.models.HECTaxCheckData.{CompanyHECTaxCheckData, Individua
 import uk.gov.hmrc.hec.models.TaxDetails.{CompanyTaxDetails, IndividualTaxDetails}
 import uk.gov.hmrc.hec.models.ids._
 import uk.gov.hmrc.hec.models.licence.{LicenceDetails, LicenceTimeTrading, LicenceType, LicenceValidityPeriod}
-import uk.gov.hmrc.hec.models.{CTAccountingPeriod, CTStatus, CTStatusResponse, CompanyHouseName, DateOfBirth, Error, HECTaxCheck, HECTaxCheckCode, HECTaxCheckData, HECTaxCheckMatchRequest, HECTaxCheckMatchResult, HECTaxCheckMatchStatus, HECTaxCheckSource, Name, TaxCheckListItem, TaxSituation, YesNoAnswer}
+import uk.gov.hmrc.hec.models.{CTAccountingPeriod, CTStatus, CTStatusResponse, CompanyHouseName, DateOfBirth, Error, HECTaxCheck, HECTaxCheckCode, HECTaxCheckData, HECTaxCheckMatchRequest, HECTaxCheckMatchResult, HECTaxCheckMatchStatus, HECTaxCheckSource, Name, TaxCheckListItem, TaxSituation, TaxYear, YesNoAnswer}
 import uk.gov.hmrc.hec.repos.HECTaxCheckStore
 import uk.gov.hmrc.hec.util.{TimeProvider, TimeUtils}
 import uk.gov.hmrc.http.HeaderCarrier
@@ -117,7 +117,7 @@ class TaxCheckServiceImplSpec extends AnyWordSpec with Matchers with MockFactory
           TaxSituation.SAPAYE,
           Some(YesNoAnswer.Yes),
           None,
-          2021
+          TaxYear(2021)
         ),
         taxCheckStartDateTime,
         HECTaxCheckSource.Digital
@@ -205,7 +205,7 @@ class TaxCheckServiceImplSpec extends AnyWordSpec with Matchers with MockFactory
               TaxSituation.SAPAYE,
               Some(YesNoAnswer.No),
               None,
-              2021
+              TaxYear(2021)
             ),
             taxCheckStartDateTime,
             HECTaxCheckSource.Digital

--- a/test/uk/gov/hmrc/hec/services/TaxCheckServiceImplSpec.scala
+++ b/test/uk/gov/hmrc/hec/services/TaxCheckServiceImplSpec.scala
@@ -116,7 +116,8 @@ class TaxCheckServiceImplSpec extends AnyWordSpec with Matchers with MockFactory
           Some(SAUTR("")),
           TaxSituation.SAPAYE,
           Some(YesNoAnswer.Yes),
-          None
+          None,
+          2021
         ),
         taxCheckStartDateTime,
         HECTaxCheckSource.Digital
@@ -203,7 +204,8 @@ class TaxCheckServiceImplSpec extends AnyWordSpec with Matchers with MockFactory
               Some(SAUTR("")),
               TaxSituation.SAPAYE,
               Some(YesNoAnswer.No),
-              None
+              None,
+              2021
             ),
             taxCheckStartDateTime,
             HECTaxCheckSource.Digital

--- a/test/uk/gov/hmrc/hec/testonly/controllers/TaxCheckControllerSpec.scala
+++ b/test/uk/gov/hmrc/hec/testonly/controllers/TaxCheckControllerSpec.scala
@@ -109,7 +109,8 @@ class TaxCheckControllerSpec extends ControllerSpec {
            |  "createDate" : "${r.createDate}",
            |  "taxCheckStartDateTime": "$getStartDateTime",
            |  "isExtracted": false,
-           |  "source" : "${r.source.toString}"
+           |  "source" : "${r.source.toString}",
+           |  "relevantIncomeTaxYear": ${r.relevantIncomeTaxYear}
            |}
            |""".stripMargin
       }
@@ -127,7 +128,8 @@ class TaxCheckControllerSpec extends ControllerSpec {
           TimeUtils.now(),
           taxCheckStartDateTime,
           false,
-          HECTaxCheckSource.Digital
+          HECTaxCheckSource.Digital,
+          2021
         )
         val body        = Json.parse(requestJsonString(request))
 
@@ -173,7 +175,8 @@ class TaxCheckControllerSpec extends ControllerSpec {
             createDate = TimeUtils.now(),
             taxCheckStartDateTime = taxCheckStartDateTime,
             isExtracted = false,
-            HECTaxCheckSource.Digital
+            HECTaxCheckSource.Digital,
+            2021
           )
           val body        = Json.parse(requestJsonString(request))
 
@@ -199,7 +202,8 @@ class TaxCheckControllerSpec extends ControllerSpec {
             TimeUtils.now(),
             taxCheckStartDateTime,
             false,
-            HECTaxCheckSource.Digital
+            HECTaxCheckSource.Digital,
+            2021
           )
           val body        = Json.parse(requestJsonString(request))
 
@@ -220,7 +224,8 @@ class TaxCheckControllerSpec extends ControllerSpec {
             TimeUtils.now(),
             taxCheckStartDateTime,
             false,
-            HECTaxCheckSource.Digital
+            HECTaxCheckSource.Digital,
+            2021
           )
           val body    = Json.parse(requestJsonString(request))
 
@@ -281,7 +286,8 @@ class TaxCheckControllerSpec extends ControllerSpec {
               Some(SAUTR("")),
               TaxSituation.SAPAYE,
               Some(YesNoAnswer.Yes),
-              None
+              None,
+              2021
             ),
             taxCheckStartDateTime,
             HECTaxCheckSource.Digital

--- a/test/uk/gov/hmrc/hec/testonly/controllers/TaxCheckControllerSpec.scala
+++ b/test/uk/gov/hmrc/hec/testonly/controllers/TaxCheckControllerSpec.scala
@@ -17,6 +17,7 @@
 package uk.gov.hmrc.hec.testonly.controllers
 
 import cats.data.EitherT
+import cats.implicits.catsSyntaxOptionId
 import cats.instances.future._
 import play.api.inject.bind
 import play.api.inject.guice.GuiceableModule
@@ -110,7 +111,7 @@ class TaxCheckControllerSpec extends ControllerSpec {
            |  "taxCheckStartDateTime": "$getStartDateTime",
            |  "isExtracted": false,
            |  "source" : "${r.source.toString}",
-           |  "relevantIncomeTaxYear": ${r.relevantIncomeTaxYear.startYear}
+           |  "relevantIncomeTaxYear": ${r.relevantIncomeTaxYear.map(_.startYear).getOrElse(2021)}
            |}
            |""".stripMargin
       }
@@ -129,7 +130,7 @@ class TaxCheckControllerSpec extends ControllerSpec {
           taxCheckStartDateTime,
           false,
           HECTaxCheckSource.Digital,
-          TaxYear(2021)
+          TaxYear(2021).some
         )
         val body        = Json.parse(requestJsonString(request))
 
@@ -176,7 +177,7 @@ class TaxCheckControllerSpec extends ControllerSpec {
             taxCheckStartDateTime = taxCheckStartDateTime,
             isExtracted = false,
             HECTaxCheckSource.Digital,
-            TaxYear(2021)
+            TaxYear(2021).some
           )
           val body        = Json.parse(requestJsonString(request))
 
@@ -203,7 +204,7 @@ class TaxCheckControllerSpec extends ControllerSpec {
             taxCheckStartDateTime,
             false,
             HECTaxCheckSource.Digital,
-            TaxYear(2021)
+            TaxYear(2021).some
           )
           val body        = Json.parse(requestJsonString(request))
 
@@ -225,7 +226,7 @@ class TaxCheckControllerSpec extends ControllerSpec {
             taxCheckStartDateTime,
             false,
             HECTaxCheckSource.Digital,
-            TaxYear(2021)
+            TaxYear(2021).some
           )
           val body    = Json.parse(requestJsonString(request))
 

--- a/test/uk/gov/hmrc/hec/testonly/controllers/TaxCheckControllerSpec.scala
+++ b/test/uk/gov/hmrc/hec/testonly/controllers/TaxCheckControllerSpec.scala
@@ -30,7 +30,7 @@ import uk.gov.hmrc.hec.models.HECTaxCheckData.IndividualHECTaxCheckData
 import uk.gov.hmrc.hec.models.TaxDetails.IndividualTaxDetails
 import uk.gov.hmrc.hec.models.ids.{CRN, GGCredId, NINO, SAUTR}
 import uk.gov.hmrc.hec.models.licence.{LicenceDetails, LicenceTimeTrading, LicenceType, LicenceValidityPeriod}
-import uk.gov.hmrc.hec.models.{DateOfBirth, Error, HECTaxCheck, HECTaxCheckCode, HECTaxCheckSource, Name, TaxSituation, YesNoAnswer}
+import uk.gov.hmrc.hec.models.{DateOfBirth, Error, HECTaxCheck, HECTaxCheckCode, HECTaxCheckSource, Name, TaxSituation, TaxYear, YesNoAnswer}
 import uk.gov.hmrc.hec.testonly.models.SaveTaxCheckRequest
 import uk.gov.hmrc.hec.testonly.services.TaxCheckService
 import uk.gov.hmrc.hec.util.TimeUtils
@@ -110,7 +110,7 @@ class TaxCheckControllerSpec extends ControllerSpec {
            |  "taxCheckStartDateTime": "$getStartDateTime",
            |  "isExtracted": false,
            |  "source" : "${r.source.toString}",
-           |  "relevantIncomeTaxYear": ${r.relevantIncomeTaxYear}
+           |  "relevantIncomeTaxYear": ${r.relevantIncomeTaxYear.startYear}
            |}
            |""".stripMargin
       }
@@ -129,7 +129,7 @@ class TaxCheckControllerSpec extends ControllerSpec {
           taxCheckStartDateTime,
           false,
           HECTaxCheckSource.Digital,
-          2021
+          TaxYear(2021)
         )
         val body        = Json.parse(requestJsonString(request))
 
@@ -176,7 +176,7 @@ class TaxCheckControllerSpec extends ControllerSpec {
             taxCheckStartDateTime = taxCheckStartDateTime,
             isExtracted = false,
             HECTaxCheckSource.Digital,
-            2021
+            TaxYear(2021)
           )
           val body        = Json.parse(requestJsonString(request))
 
@@ -203,7 +203,7 @@ class TaxCheckControllerSpec extends ControllerSpec {
             taxCheckStartDateTime,
             false,
             HECTaxCheckSource.Digital,
-            2021
+            TaxYear(2021)
           )
           val body        = Json.parse(requestJsonString(request))
 
@@ -225,7 +225,7 @@ class TaxCheckControllerSpec extends ControllerSpec {
             taxCheckStartDateTime,
             false,
             HECTaxCheckSource.Digital,
-            2021
+            TaxYear(2021)
           )
           val body    = Json.parse(requestJsonString(request))
 
@@ -287,7 +287,7 @@ class TaxCheckControllerSpec extends ControllerSpec {
               TaxSituation.SAPAYE,
               Some(YesNoAnswer.Yes),
               None,
-              2021
+              TaxYear(2021)
             ),
             taxCheckStartDateTime,
             HECTaxCheckSource.Digital

--- a/test/uk/gov/hmrc/hec/testonly/services/TaxCheckServiceImplSpec.scala
+++ b/test/uk/gov/hmrc/hec/testonly/services/TaxCheckServiceImplSpec.scala
@@ -41,10 +41,11 @@ import scala.concurrent.ExecutionContext.Implicits.global
 class TaxCheckServiceImplSpec extends AnyWordSpec with Matchers with MockFactory {
 
   val mockTaxCheckStore = mock[HECTaxCheckStore]
+  val mockTimeProvider  = mock[TimeProvider]
 
   val taxCheckStartDateTime = ZonedDateTime.of(2021, 10, 9, 9, 12, 34, 0, ZoneId.of("Europe/London"))
 
-  val service = new TaxCheckServiceImpl(mockTaxCheckStore)
+  val service = new TaxCheckServiceImpl(mockTaxCheckStore, mockTimeProvider)
 
   def mockStoreTaxCheck(taxCheck: HECTaxCheck)(result: Either[Error, Unit]) =
     (mockTaxCheckStore
@@ -70,8 +71,6 @@ class TaxCheckServiceImplSpec extends AnyWordSpec with Matchers with MockFactory
       .expects(*)
       .returning(EitherT.fromEither(result))
 
-  val mockTimeProvider = mock[TimeProvider]
-
   def mockTimeProviderToday(d: LocalDate) = (mockTimeProvider.currentDate _).expects().returning(d)
   val fileCorrelationId                   = UUID.fromString("20354d7a-e4fe-47af-8ff6-187bca92f3f9")
 
@@ -95,7 +94,7 @@ class TaxCheckServiceImplSpec extends AnyWordSpec with Matchers with MockFactory
           taxCheckStartDateTime,
           false,
           HECTaxCheckSource.Digital,
-          TaxYear(2021)
+          TaxYear(2021).some
         )
 
       "return an error" when {

--- a/test/uk/gov/hmrc/hec/testonly/services/TaxCheckServiceImplSpec.scala
+++ b/test/uk/gov/hmrc/hec/testonly/services/TaxCheckServiceImplSpec.scala
@@ -28,7 +28,7 @@ import uk.gov.hmrc.hec.models.HECTaxCheckData.IndividualHECTaxCheckData
 import uk.gov.hmrc.hec.models.TaxDetails.IndividualTaxDetails
 import uk.gov.hmrc.hec.models.ids.{CRN, GGCredId, NINO, SAUTR}
 import uk.gov.hmrc.hec.models.licence.{LicenceDetails, LicenceTimeTrading, LicenceType, LicenceValidityPeriod}
-import uk.gov.hmrc.hec.models.{DateOfBirth, Error, HECTaxCheck, HECTaxCheckCode, HECTaxCheckSource, Name, TaxSituation, YesNoAnswer}
+import uk.gov.hmrc.hec.models.{DateOfBirth, Error, HECTaxCheck, HECTaxCheckCode, HECTaxCheckSource, Name, TaxSituation, TaxYear, YesNoAnswer}
 import uk.gov.hmrc.hec.repos.HECTaxCheckStore
 import uk.gov.hmrc.hec.testonly.models.SaveTaxCheckRequest
 import uk.gov.hmrc.hec.util.{TimeProvider, TimeUtils}
@@ -95,7 +95,7 @@ class TaxCheckServiceImplSpec extends AnyWordSpec with Matchers with MockFactory
           taxCheckStartDateTime,
           false,
           HECTaxCheckSource.Digital,
-          2021
+          TaxYear(2021)
         )
 
       "return an error" when {
@@ -195,7 +195,7 @@ class TaxCheckServiceImplSpec extends AnyWordSpec with Matchers with MockFactory
               TaxSituation.SAPAYE,
               Some(YesNoAnswer.Yes),
               None,
-              2021
+              TaxYear(2021)
             ),
             taxCheckStartDateTime,
             HECTaxCheckSource.Digital

--- a/test/uk/gov/hmrc/hec/testonly/services/TaxCheckServiceImplSpec.scala
+++ b/test/uk/gov/hmrc/hec/testonly/services/TaxCheckServiceImplSpec.scala
@@ -94,7 +94,8 @@ class TaxCheckServiceImplSpec extends AnyWordSpec with Matchers with MockFactory
           now,
           taxCheckStartDateTime,
           false,
-          HECTaxCheckSource.Digital
+          HECTaxCheckSource.Digital,
+          2021
         )
 
       "return an error" when {
@@ -193,7 +194,8 @@ class TaxCheckServiceImplSpec extends AnyWordSpec with Matchers with MockFactory
               Some(SAUTR("")),
               TaxSituation.SAPAYE,
               Some(YesNoAnswer.Yes),
-              None
+              None,
+              2021
             ),
             taxCheckStartDateTime,
             HECTaxCheckSource.Digital


### PR DESCRIPTION
As a part of [HEC-1420](https://jira.tools.tax.service.gov.uk/browse/HEC-1420), adding new field relevantIncomeTaxYear in HecTaxCheck model. This branch will only be  merged together with  applicant-FE and stride-FE changes.