### PR TITLE
Hec 1533 make ggcredid optional

### DIFF
--- a/app/uk/gov/hmrc/hec/models/ApplicantDetails.scala
+++ b/app/uk/gov/hmrc/hec/models/ApplicantDetails.scala
@@ -30,7 +30,7 @@ object ApplicantDetails {
   ) extends ApplicantDetails
 
   final case class CompanyApplicantDetails(
-    ggCredId: GGCredId,
+    ggCredId: Option[GGCredId],
     crn: CRN,
     companyName: CompanyHouseName
   ) extends ApplicantDetails

--- a/app/uk/gov/hmrc/hec/models/CTAccountingPeriod.scala
+++ b/app/uk/gov/hmrc/hec/models/CTAccountingPeriod.scala
@@ -21,7 +21,7 @@ import play.api.libs.json.{Json, OFormat}
 import java.time.LocalDate
 
 final case class CTAccountingPeriod(
-  startDate: LocalDate,
+  startDate: Option[LocalDate],
   endDate: LocalDate,
   ctStatus: CTStatus
 )

--- a/app/uk/gov/hmrc/hec/services/FileCreationService.scala
+++ b/app/uk/gov/hmrc/hec/services/FileCreationService.scala
@@ -211,7 +211,7 @@ class FileCreationServiceImpl @Inject() (timeProvider: TimeProvider) extends Fil
             entityType = 'C',
             notChargeable = getNotChargeableInfo(c.taxDetails.chargeableForCT),
             hasAccountingPeriod = ctStatusMap.accountingPeriod,
-            accountingPeriodStartDate = accountingPeriod.map(_.startDate.format(DATE_FORMATTER)),
+            accountingPeriodStartDate = accountingPeriod.flatMap(_.startDate.map(_.format(DATE_FORMATTER))),
             accountingPeriodEndDate = accountingPeriod.map(_.endDate.format(DATE_FORMATTER)),
             recentlyStartedTrading = yesNoAnswerMap(c.taxDetails.recentlyStaredTrading),
             returnReceived = ctStatusMap.returnReceived,

--- a/app/uk/gov/hmrc/hec/services/FileCreationService.scala
+++ b/app/uk/gov/hmrc/hec/services/FileCreationService.scala
@@ -201,7 +201,7 @@ class FileCreationServiceImpl @Inject() (timeProvider: TimeProvider) extends Fil
           val ctStatus         = accountingPeriod.map(_.ctStatus)
           val ctStatusMap      = ctStatusMapping(ctStatus)
           HECTaxCheckFileBody(
-            ggCredID = Some(c.applicantDetails.ggCredId.value),
+            ggCredID = c.applicantDetails.ggCredId.map(_.value),
             CTUTR = Some(c.taxDetails.desCTUTR.value),
             crn = Some(c.applicantDetails.crn.value),
             companyName = Some(c.applicantDetails.companyName.name),

--- a/app/uk/gov/hmrc/hec/services/IFService.scala
+++ b/app/uk/gov/hmrc/hec/services/IFService.scala
@@ -136,7 +136,7 @@ class IFServiceImpl @Inject() (
           .getOrElse(List.empty[RawAccountingPeriod])
           .traverse[Either[BackendError, *], CTAccountingPeriod](a =>
             toCtStatus(a)
-              .map(status => CTAccountingPeriod(a.accountingPeriodStartDate, a.accountingPeriodEndDate, status))
+              .map(status => CTAccountingPeriod(a.accountingPeriodStartDate.some, a.accountingPeriodEndDate, status))
           )
           .filterOrElse(
             _.nonEmpty,

--- a/app/uk/gov/hmrc/hec/testonly/services/TaxCheckService.scala
+++ b/app/uk/gov/hmrc/hec/testonly/services/TaxCheckService.scala
@@ -17,6 +17,7 @@
 package uk.gov.hmrc.hec.testonly.services
 
 import cats.data.EitherT
+import cats.implicits.catsSyntaxOptionId
 import com.google.inject.{ImplementedBy, Inject, Singleton}
 import uk.gov.hmrc.hec.models.ApplicantDetails.{CompanyApplicantDetails, IndividualApplicantDetails}
 import uk.gov.hmrc.hec.models.HECTaxCheckData.{CompanyHECTaxCheckData, IndividualHECTaxCheckData}
@@ -94,7 +95,7 @@ class TaxCheckServiceImpl @Inject() (
 
     saveTaxCheckRequest.verifier match {
       case Left(crn) =>
-        val companyDetails    = CompanyApplicantDetails(ggCredId, crn, CompanyHouseName("Test Tech Ltd"))
+        val companyDetails    = CompanyApplicantDetails(ggCredId.some, crn, CompanyHouseName("Test Tech Ltd"))
         val companyTaxDetails = CompanyTaxDetails(
           CTUTR("1111111111"),
           Some(CTUTR("1111111111")),

--- a/app/uk/gov/hmrc/hec/testonly/services/TaxCheckService.scala
+++ b/app/uk/gov/hmrc/hec/testonly/services/TaxCheckService.scala
@@ -104,7 +104,7 @@ class TaxCheckServiceImpl @Inject() (
             CTUTR("1111111111"),
             LocalDate.of(2020, 10, 9),
             LocalDate.of(2021, 10, 9),
-            Some(CTAccountingPeriod(LocalDate.of(2020, 10, 9), LocalDate.of(2021, 10, 9), CTStatus.ReturnFound))
+            Some(CTAccountingPeriod(LocalDate.of(2020, 10, 9).some, LocalDate.of(2021, 10, 9), CTStatus.ReturnFound))
           ),
           None,
           Some(YesNoAnswer.Yes)

--- a/test/uk/gov/hmrc/hec/controllers/SDESCallbackControllerSpec.scala
+++ b/test/uk/gov/hmrc/hec/controllers/SDESCallbackControllerSpec.scala
@@ -90,7 +90,7 @@ class SDESCallbackControllerSpec extends ControllerSpec {
   val ggCredId                      = GGCredId("ggCredId")
   val taxCheckStartDateTime         = ZonedDateTime.of(2021, 10, 9, 9, 12, 34, 0, ZoneId.of("Europe/London"))
   val taxCheckData: HECTaxCheckData = CompanyHECTaxCheckData(
-    CompanyApplicantDetails(ggCredId, CRN(""), CompanyHouseName("Test Tech Ltd")),
+    CompanyApplicantDetails(ggCredId.some, CRN(""), CompanyHouseName("Test Tech Ltd")),
     LicenceDetails(
       LicenceType.ScrapMetalDealerSite,
       LicenceTimeTrading.EightYearsOrMore,

--- a/test/uk/gov/hmrc/hec/controllers/TaxCheckControllerSpec.scala
+++ b/test/uk/gov/hmrc/hec/controllers/TaxCheckControllerSpec.scala
@@ -17,6 +17,7 @@
 package uk.gov.hmrc.hec.controllers
 
 import cats.data.EitherT
+import cats.implicits.catsSyntaxOptionId
 import cats.instances.future._
 import com.github.ghik.silencer.silent
 import play.api.inject.bind
@@ -106,7 +107,7 @@ class TaxCheckControllerSpec extends ControllerSpec with AuthSupport {
       )
 
       val taxCheckDataCompany: HECTaxCheckData = CompanyHECTaxCheckData(
-        CompanyApplicantDetails(GGCredId(""), CRN("12345678"), CompanyHouseName("Test Tech Ltd")),
+        CompanyApplicantDetails(GGCredId("").some, CRN("12345678"), CompanyHouseName("Test Tech Ltd")),
         LicenceDetails(
           LicenceType.ScrapMetalDealerSite,
           LicenceTimeTrading.EightYearsOrMore,

--- a/test/uk/gov/hmrc/hec/controllers/TaxCheckControllerSpec.scala
+++ b/test/uk/gov/hmrc/hec/controllers/TaxCheckControllerSpec.scala
@@ -121,7 +121,7 @@ class TaxCheckControllerSpec extends ControllerSpec with AuthSupport {
             CTUTR("1111111111"),
             LocalDate.of(2020, 10, 9),
             LocalDate.of(2021, 10, 9),
-            Some(CTAccountingPeriod(LocalDate.of(2020, 10, 9), LocalDate.of(2021, 10, 9), CTStatus.ReturnFound))
+            Some(CTAccountingPeriod(LocalDate.of(2020, 10, 9).some, LocalDate.of(2021, 10, 9), CTStatus.ReturnFound))
           ),
           None,
           Some(YesNoAnswer.Yes)

--- a/test/uk/gov/hmrc/hec/models/HECTaxCheckDataSpec.scala
+++ b/test/uk/gov/hmrc/hec/models/HECTaxCheckDataSpec.scala
@@ -16,6 +16,8 @@
 
 package uk.gov.hmrc.hec.models
 
+import cats.implicits.catsSyntaxOptionId
+
 import java.time.{LocalDate, ZoneId, ZonedDateTime}
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
@@ -88,7 +90,7 @@ class HECTaxCheckDataSpec extends AnyWordSpec with Matchers {
 
       val companyTaxCheckData: HECTaxCheckData =
         CompanyHECTaxCheckData(
-          CompanyApplicantDetails(GGCredId("ggCredId"), CRN("12345678"), CompanyHouseName("Test Tech Ltd")),
+          CompanyApplicantDetails(GGCredId("ggCredId").some, CRN("12345678"), CompanyHouseName("Test Tech Ltd")),
           LicenceDetails(
             LicenceType.ScrapMetalMobileCollector,
             LicenceTimeTrading.EightYearsOrMore,

--- a/test/uk/gov/hmrc/hec/models/HECTaxCheckDataSpec.scala
+++ b/test/uk/gov/hmrc/hec/models/HECTaxCheckDataSpec.scala
@@ -104,8 +104,9 @@ class HECTaxCheckDataSpec extends AnyWordSpec with Matchers {
               ctutr = CTUTR("1111111111"),
               startDate = LocalDate.of(2020, 10, 9),
               endDate = LocalDate.of(2021, 10, 9),
-              latestAccountingPeriod =
-                Some(CTAccountingPeriod(LocalDate.of(2020, 10, 9), LocalDate.of(2021, 10, 9), CTStatus.ReturnFound))
+              latestAccountingPeriod = Some(
+                CTAccountingPeriod(LocalDate.of(2020, 10, 9).some, LocalDate.of(2021, 10, 9), CTStatus.ReturnFound)
+              )
             ),
             recentlyStaredTrading = None,
             Some(YesNoAnswer.Yes)

--- a/test/uk/gov/hmrc/hec/repos/HECTaxCheckStoreImplSpec.scala
+++ b/test/uk/gov/hmrc/hec/repos/HECTaxCheckStoreImplSpec.scala
@@ -74,7 +74,7 @@ class HECTaxCheckStoreImplSpec extends AnyWordSpec with Matchers with Eventually
           CTUTR("1111111111"),
           LocalDate.of(2020, 10, 9),
           LocalDate.of(2021, 10, 9),
-          Some(CTAccountingPeriod(LocalDate.of(2020, 10, 9), LocalDate.of(2021, 10, 9), CTStatus.ReturnFound))
+          Some(CTAccountingPeriod(LocalDate.of(2020, 10, 9).some, LocalDate.of(2021, 10, 9), CTStatus.ReturnFound))
         ),
         None,
         Some(YesNoAnswer.Yes)

--- a/test/uk/gov/hmrc/hec/repos/HECTaxCheckStoreImplSpec.scala
+++ b/test/uk/gov/hmrc/hec/repos/HECTaxCheckStoreImplSpec.scala
@@ -60,7 +60,7 @@ class HECTaxCheckStoreImplSpec extends AnyWordSpec with Matchers with Eventually
     val taxCheckStartDateTime = ZonedDateTime.of(2021, 10, 9, 9, 12, 34, 0, ZoneId.of("Europe/London"))
 
     val taxCheckData = CompanyHECTaxCheckData(
-      CompanyApplicantDetails(GGCredId(""), CRN(""), CompanyHouseName("Test Tech Ltd")),
+      CompanyApplicantDetails(GGCredId("").some, CRN(""), CompanyHouseName("Test Tech Ltd")),
       LicenceDetails(
         LicenceType.ScrapMetalDealerSite,
         LicenceTimeTrading.EightYearsOrMore,
@@ -161,7 +161,7 @@ class HECTaxCheckStoreImplSpec extends AnyWordSpec with Matchers with Eventually
     }
 
     "be able to fetch all tax check codes using the GGCredId" in {
-      val ggCredId = taxCheckData.applicantDetails.ggCredId
+      val ggCredId = taxCheckData.applicantDetails.ggCredId.getOrElse(sys.error("ggCredId not found in DB"))
 
       // store some tax check codes in mongo
       await(taxCheckStore.store(taxCheck1).value) shouldBe Right(())

--- a/test/uk/gov/hmrc/hec/services/FileCreationServiceSpec.scala
+++ b/test/uk/gov/hmrc/hec/services/FileCreationServiceSpec.scala
@@ -393,7 +393,7 @@ class FileCreationServiceSpec extends AnyWordSpec with Matchers with MockFactory
               CTUTR("1111111111"),
               startDate,
               endDate,
-              Some(CTAccountingPeriod(startDate, endDate, status))
+              Some(CTAccountingPeriod(startDate.some, endDate, status))
             )
 
             def createTaxDetails(

--- a/test/uk/gov/hmrc/hec/services/FileCreationServiceSpec.scala
+++ b/test/uk/gov/hmrc/hec/services/FileCreationServiceSpec.scala
@@ -16,6 +16,7 @@
 
 package uk.gov.hmrc.hec.services
 
+import cats.implicits.catsSyntaxOptionId
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
@@ -386,7 +387,7 @@ class FileCreationServiceSpec extends AnyWordSpec with Matchers with MockFactory
             val endDate   = LocalDate.of(2021, 10, 9)
 
             val companyDetails =
-              CompanyApplicantDetails(GGCredId("AB123"), CRN("1123456"), CompanyHouseName("Test Tech Ltd"))
+              CompanyApplicantDetails(GGCredId("AB123").some, CRN("1123456"), CompanyHouseName("Test Tech Ltd"))
 
             def getCTStatusResponse(status: CTStatus) = CTStatusResponse(
               CTUTR("1111111111"),

--- a/test/uk/gov/hmrc/hec/services/HecTaxCheckExtractionServiceSpec.scala
+++ b/test/uk/gov/hmrc/hec/services/HecTaxCheckExtractionServiceSpec.scala
@@ -154,7 +154,7 @@ class HecTaxCheckExtractionServiceSpec
   "HecTaxCheckExtractionServiceSpec" must {
 
     val taxCheckData  = CompanyHECTaxCheckData(
-      CompanyApplicantDetails(GGCredId(""), CRN(""), CompanyHouseName("Test Tech Ltd")),
+      CompanyApplicantDetails(GGCredId("").some, CRN(""), CompanyHouseName("Test Tech Ltd")),
       LicenceDetails(
         LicenceType.ScrapMetalDealerSite,
         LicenceTimeTrading.EightYearsOrMore,

--- a/test/uk/gov/hmrc/hec/services/HecTaxCheckExtractionServiceSpec.scala
+++ b/test/uk/gov/hmrc/hec/services/HecTaxCheckExtractionServiceSpec.scala
@@ -168,7 +168,7 @@ class HecTaxCheckExtractionServiceSpec
           CTUTR("1111111111"),
           LocalDate.of(2020, 10, 9),
           LocalDate.of(2021, 10, 9),
-          Some(CTAccountingPeriod(LocalDate.of(2020, 10, 9), LocalDate.of(2021, 10, 9), CTStatus.ReturnFound))
+          Some(CTAccountingPeriod(LocalDate.of(2020, 10, 9).some, LocalDate.of(2021, 10, 9), CTStatus.ReturnFound))
         ),
         None,
         Some(YesNoAnswer.Yes)

--- a/test/uk/gov/hmrc/hec/services/IFServiceImplSpec.scala
+++ b/test/uk/gov/hmrc/hec/services/IFServiceImplSpec.scala
@@ -18,8 +18,8 @@ package uk.gov.hmrc.hec.services
 
 import java.time.LocalDate
 import java.util.UUID
-
 import cats.data.EitherT
+import cats.implicits.catsSyntaxOptionId
 import cats.instances.future._
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.OptionValues._
@@ -365,7 +365,7 @@ class IFServiceImplSpec extends AnyWordSpec with Matchers with MockFactory {
               toDate,
               Some(
                 CTAccountingPeriod(
-                  LocalDate.of(2020, 10, 15),
+                  LocalDate.of(2020, 10, 15).some,
                   LocalDate.of(2021, 10, 20),
                   expectedCtStatus
                 )

--- a/test/uk/gov/hmrc/hec/services/TaxCheckServiceImplSpec.scala
+++ b/test/uk/gov/hmrc/hec/services/TaxCheckServiceImplSpec.scala
@@ -233,7 +233,9 @@ class TaxCheckServiceImplSpec extends AnyWordSpec with Matchers with MockFactory
                 CTUTR("1111111111"),
                 LocalDate.of(2020, 10, 9),
                 LocalDate.of(2021, 10, 9),
-                Some(CTAccountingPeriod(LocalDate.of(2020, 10, 9), LocalDate.of(2021, 10, 9), CTStatus.ReturnFound))
+                Some(
+                  CTAccountingPeriod(LocalDate.of(2020, 10, 9).some, LocalDate.of(2021, 10, 9), CTStatus.ReturnFound)
+                )
               ),
               None,
               Some(YesNoAnswer.Yes)
@@ -441,7 +443,7 @@ class TaxCheckServiceImplSpec extends AnyWordSpec with Matchers with MockFactory
             CTUTR("1111111111"),
             LocalDate.of(2020, 10, 9),
             LocalDate.of(2021, 10, 9),
-            Some(CTAccountingPeriod(LocalDate.of(2020, 10, 9), LocalDate.of(2021, 10, 9), CTStatus.ReturnFound))
+            Some(CTAccountingPeriod(LocalDate.of(2020, 10, 9).some, LocalDate.of(2021, 10, 9), CTStatus.ReturnFound))
           ),
           None,
           Some(YesNoAnswer.Yes)
@@ -512,7 +514,7 @@ class TaxCheckServiceImplSpec extends AnyWordSpec with Matchers with MockFactory
             CTUTR("1111111111"),
             LocalDate.of(2020, 10, 9),
             LocalDate.of(2021, 10, 9),
-            Some(CTAccountingPeriod(LocalDate.of(2020, 10, 9), LocalDate.of(2021, 10, 9), CTStatus.ReturnFound))
+            Some(CTAccountingPeriod(LocalDate.of(2020, 10, 9).some, LocalDate.of(2021, 10, 9), CTStatus.ReturnFound))
           ),
           None,
           Some(YesNoAnswer.Yes)
@@ -567,7 +569,7 @@ class TaxCheckServiceImplSpec extends AnyWordSpec with Matchers with MockFactory
             CTUTR("1111111111"),
             LocalDate.of(2020, 10, 9),
             LocalDate.of(2021, 10, 9),
-            Some(CTAccountingPeriod(LocalDate.of(2020, 10, 9), LocalDate.of(2021, 10, 9), CTStatus.ReturnFound))
+            Some(CTAccountingPeriod(LocalDate.of(2020, 10, 9).some, LocalDate.of(2021, 10, 9), CTStatus.ReturnFound))
           ),
           None,
           Some(YesNoAnswer.Yes)

--- a/test/uk/gov/hmrc/hec/services/TaxCheckServiceImplSpec.scala
+++ b/test/uk/gov/hmrc/hec/services/TaxCheckServiceImplSpec.scala
@@ -223,7 +223,7 @@ class TaxCheckServiceImplSpec extends AnyWordSpec with Matchers with MockFactory
       val storedCompanyTaxCheck =
         HECTaxCheck(
           CompanyHECTaxCheckData(
-            CompanyApplicantDetails(GGCredId(""), storedCRN, CompanyHouseName("Test Tech Ltd")),
+            CompanyApplicantDetails(GGCredId("").some, storedCRN, CompanyHouseName("Test Tech Ltd")),
             storedLicenceDetails,
             CompanyTaxDetails(
               CTUTR("1111111111"),
@@ -427,7 +427,7 @@ class TaxCheckServiceImplSpec extends AnyWordSpec with Matchers with MockFactory
       val today    = LocalDate.of(2020, 1, 10)
 
       val taxCheckData = CompanyHECTaxCheckData(
-        CompanyApplicantDetails(ggCredId, CRN(""), CompanyHouseName("Test Tech Ltd")),
+        CompanyApplicantDetails(ggCredId.some, CRN(""), CompanyHouseName("Test Tech Ltd")),
         LicenceDetails(
           LicenceType.ScrapMetalDealerSite,
           LicenceTimeTrading.EightYearsOrMore,
@@ -498,7 +498,7 @@ class TaxCheckServiceImplSpec extends AnyWordSpec with Matchers with MockFactory
       val ggCredId = GGCredId("ggCredId")
 
       val taxCheckData: HECTaxCheckData = CompanyHECTaxCheckData(
-        CompanyApplicantDetails(ggCredId, CRN(""), CompanyHouseName("Test Tech Ltd")),
+        CompanyApplicantDetails(ggCredId.some, CRN(""), CompanyHouseName("Test Tech Ltd")),
         LicenceDetails(
           LicenceType.ScrapMetalDealerSite,
           LicenceTimeTrading.EightYearsOrMore,
@@ -553,7 +553,7 @@ class TaxCheckServiceImplSpec extends AnyWordSpec with Matchers with MockFactory
       val uuid     = UUID.randomUUID()
 
       val taxCheckData: HECTaxCheckData = CompanyHECTaxCheckData(
-        CompanyApplicantDetails(ggCredId, CRN(""), CompanyHouseName("Test Tech Ltd")),
+        CompanyApplicantDetails(ggCredId.some, CRN(""), CompanyHouseName("Test Tech Ltd")),
         LicenceDetails(
           LicenceType.ScrapMetalDealerSite,
           LicenceTimeTrading.EightYearsOrMore,


### PR DESCRIPTION
In order to save stride data, we need to make company's ggCredId and start date of accounting period as optional as these two are not available in stride journey