### PR TITLE
DDCYLS-6971: removing the partial index from file correlation id

### DIFF
--- a/app/uk/gov/hmrc/hec/repos/HECTaxCheckStore.scala
+++ b/app/uk/gov/hmrc/hec/repos/HECTaxCheckStore.scala
@@ -108,7 +108,6 @@ class HECTaxCheckStoreImpl @Inject() (
       Indexes.ascending("fileCorrelationId"),
       IndexOptions()
         .name("fileCorrelationIdIndex")
-        .partialFilterExpression(Filters.exists("fileCorrelationId"))
     )
   )
 


### PR DESCRIPTION
removing the partial index from file correlation id as will only create the index the file correlation id is populated.